### PR TITLE
- fixed unsigned/signed comparison error

### DIFF
--- a/EasyIot7/src/Config.cpp
+++ b/EasyIot7/src/Config.cpp
@@ -367,7 +367,19 @@ void load(Config &config)
 #ifdef DEBUG
     Log.error("%s File storage can't start" CR, tags::config);
 #endif
-    return;
+    // We can't return here, or else the application will continue, thinking
+    // it can access Config::* when in fact it wasn't initialized yet.
+    // We inform the user about the error, but, we do not return
+    // triggering the next if, where it'll load defaults.
+    // If we do not initialize defaults, app will crash at MDNS refresh
+    // when it attempts to create a service using Config::* variables.
+    //return;
+    if(!LittleFS.format())
+    {
+#ifdef DEBUG
+    Log.error("%s Unable to format Filesystem, please ensure you built firmware with filesystem support." CR, tags::config);
+#endif
+    }
   }
 
   if (!LittleFS.exists(configFilenames::config))

--- a/EasyIot7/src/Serial.cpp
+++ b/EasyIot7/src/Serial.cpp
@@ -322,7 +322,7 @@ void TasmotaSerial::rxRead()
     }
     // Store the received value in the buffer unless we have an overflow
     unsigned int next = (m_in_pos + 1) % TM_SERIAL_BUFFER_SIZE;
-    if (next != (int)m_out_pos)
+    if (next != static_cast<unsigned int>(m_out_pos))
     {
         m_buffer[m_in_pos] = rec;
         m_in_pos = next;

--- a/EasyIot7/src/Switches.cpp
+++ b/EasyIot7/src/Switches.cpp
@@ -394,39 +394,63 @@ void switchesCallback(message_t const &msg, void *arg)
   auto s = static_cast<SwitchT *>(arg);
   switch (msg.ct)
   {
-  case KNX_CT_WRITE:
-  {
-    int stateIdx = (int)msg.data[1];
-    s->changeState(STATES_POLL[stateIdx].c_str(), "KNX");
-
-    break;
-  }
-  case KNX_CT_READ:
-  {
-    break;
-  }
-  }
+    case KNX_CT_ADC_ANSWER:
+    case KNX_CT_ADC_READ:
+    case KNX_CT_ANSWER:
+    case KNX_CT_ESCAPE:
+    case KNX_CT_INDIVIDUAL_ADDR_REQUEST:
+    case KNX_CT_INDIVIDUAL_ADDR_RESPONSE:
+    case KNX_CT_INDIVIDUAL_ADDR_WRITE:
+    case KNX_CT_MASK_VERSION_READ:
+    case KNX_CT_MASK_VERSION_RESPONSE:
+    case KNX_CT_MEM_ANSWER:
+    case KNX_CT_MEM_READ:
+    case KNX_CT_MEM_WRITE:
+    case KNX_CT_READ:
+    case KNX_CT_RESTART:
+      break;
+  
+    case KNX_CT_WRITE:
+    {
+      int stateIdx = (int)msg.data[1];
+      s->changeState(STATES_POLL[stateIdx].c_str(), "KNX");
+      break;
+    }
+  };
 }
+
 void allwitchesCallback(message_t const &msg, void *arg)
 {
   switch (msg.ct)
   {
-  case KNX_CT_WRITE:
-  {
-    int stateIdx = (int)msg.data[0];
-    for (auto &sw : getAtualSwitchesConfig().items)
-    {
-      sw.changeState(STATES_POLL[stateIdx].c_str(), "KNX");
-    }
-    break;
-  }
-  case KNX_CT_READ:
-  {
+    case KNX_CT_ADC_ANSWER:
+    case KNX_CT_ADC_READ:
+    case KNX_CT_ANSWER:
+    case KNX_CT_ESCAPE:
+    case KNX_CT_INDIVIDUAL_ADDR_REQUEST:
+    case KNX_CT_INDIVIDUAL_ADDR_RESPONSE:
+    case KNX_CT_INDIVIDUAL_ADDR_WRITE:
+    case KNX_CT_MASK_VERSION_READ:
+    case KNX_CT_MASK_VERSION_RESPONSE:
+    case KNX_CT_MEM_ANSWER:
+    case KNX_CT_MEM_READ:
+    case KNX_CT_MEM_WRITE:
+    case KNX_CT_READ:
+    case KNX_CT_RESTART:
+      break;
 
-    break;
-  }
-  }
+    case KNX_CT_WRITE:
+    {
+      int stateIdx = (int)msg.data[0];
+      for (auto &sw : getAtualSwitchesConfig().items)
+      {
+        sw.changeState(STATES_POLL[stateIdx].c_str(), "KNX");
+      }
+      break;
+    }
+  };
 }
+
 void Switches::load(File &file)
 {
   knx.start(nullptr);


### PR DESCRIPTION
- fixed unhandled enumeration error
- fixed obscure bug, when firmware isn't compiled with FS support (filesystem size = 0kb), an error is thrown when initializing LittleFS, and the application returned with Config in an unknown uninitialized
state, and as soon as MDNS refresh happened, it would crash attempting to copy unknown memory area when initializing MDNS zones, leaving the unit in an endless crash loop. Now throws an error in the log,
while on debug, maybe it should be more explicit !!