### PR TITLE
fix(cloudio): normalize firmware version in config payload

### DIFF
--- a/src/CloudIO.cpp
+++ b/src/CloudIO.cpp
@@ -191,6 +191,15 @@ void connectToCloudIO()
   JsonDocument doc;
   JsonVariant root = doc.to<JsonVariant>();
   config.json(root, false);
+  // CloudIO backend expects numeric firmware format (e.g. 9.17).
+  // Keep local/UI version tags (e.g. 9.17-dev), but strip suffix for this API call.
+  String firmwareForCloud = String(VERSION);
+  int versionSuffixIndex = firmwareForCloud.indexOf('-');
+  if (versionSuffixIndex > 0)
+  {
+    firmwareForCloud = firmwareForCloud.substring(0, versionSuffixIndex);
+  }
+  root["firmware"] = firmwareForCloud;
   serializeJson(doc, payload);
   http.begin(client, constanstsCloudIO::configUrl);
   http.addHeader("Content-Type", "application/json");


### PR DESCRIPTION
(cherry picked from commit 37333f046f3fd02c49b5dd42764446ce76623b24)

Fix CloudIO config for dev builds: keep local version tags (e.g. 9.17-dev) but send normalized firmware version (9.17) to CloudIO payload to prevent HTTP 500 and restore stable app adoption/control.

