### PR TITLE
chore(gitignore): dedupe entries and ignore release notes draft

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,10 +3,6 @@ package.json
 node_modules
 .DS_Store
 .pio
+platformio_override.ini
 .vscode
-.gitignore
-.vscode/launch.json
-.vscode/c_cpp_properties.json
-
-
-.DS_Store
+RELEASE_NOTES_DRAFT.md


### PR DESCRIPTION
(cherry picked from commit ad9378aa197ac942c09eab4c2090f7a28309c038)

This PR cleans and standardizes .gitignore: removes duplicate entries, keeps platformio_override.ini ignored, and adds RELEASE_NOTES_DRAFT.md so generated draft notes stay local and are not accidentally committed.