### PR TITLE
build: enforce WEB_SECURE_ON in production profiles

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ build_unflags=
 [env:ESP32-MAKER-4MB_RELEASE]
 extends = ESP32_4M
 build_unflags=
-    -D WEB_SECURE_ON 
+    -D DEBUG_ONOFRE
     -D TEST_TEMPLATE
 
 [env:ESP32_DEBUG]
@@ -143,7 +143,7 @@ build_unflags=
 [env:ESP32C3_HAN]
 extends = ESP32_C3
 build_unflags=
-    -D WEB_SECURE_ON 
+    -D DEBUG_ONOFRE
     -D TEST_TEMPLATE
     -D LEGACY_PROVISON
 
@@ -178,6 +178,7 @@ build_unflags=
 extends = ESP8266
 build_unflags=
     -D DEBUG_ONOFRE
+    -D TEST_TEMPLATE
 
 [env:ESP8266-HAN_DEBUG]
 extends = ESP8266


### PR DESCRIPTION
(cherry picked from commit 51288d53010899f7a08bb1f6b009a505e289f2a8)

## Summary
Hardened production profile flags so secure web mode stays enabled and release builds avoid debug/test defaults.

## Changes
- `platformio.ini`
  - `env:ESP32-MAKER-4MB_RELEASE`
    - removed `-D WEB_SECURE_ON` from `build_unflags`
    - added `-D DEBUG_ONOFRE` to `build_unflags`
  - `env:ESP32C3_HAN`
    - removed `-D WEB_SECURE_ON` from `build_unflags`
    - added `-D DEBUG_ONOFRE` to `build_unflags`
  - `env:ESP8266-HAN_RELEASE`
    - added `-D TEST_TEMPLATE` to `build_unflags`

## Validation
- Scoped validator checks pass for affected envs.
- Release build passes for `ESP32-MAKER-4MB_RELEASE`.
- `WEB_SECURE_ON` now remains active on non-debug production profiles.
