### PR TITLE
security(api): use POST for state-changing endpoints

### DIFF
--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -1,7 +1,7 @@
 # EasyIot - To Do
 
 Created by: Alexandru Hauzman  
-Updated: 11.02.2026  
+Updated: 13.02.2026  
 Current version: 9.17-dev
 
 ## Important Notes
@@ -21,7 +21,6 @@ Current version: 9.17-dev
 
 1. [ ] Move cloud config/OTA URLs from `http://` to secure transport and validate update path. File: `include/Constants.h`
 2. [ ] Remove Wi-Fi password from debug logs (never print secrets). File: `src/CoreWiFi.cpp`
-3. [ ] Convert state-changing endpoints from GET to POST (`/reboot`, `/load-defaults`, `/templates/change`). File: `src/WebServer.cpp`
 4. [ ] Ensure release profiles enforce `WEB_SECURE_ON` and avoid debug defaults in production builds. File: `platformio.ini`
 5. [ ] Remove password logging for AP/API changes in debug logs. File: `src/ConfigOnofre.cpp`
 6. [ ] Replace default credentials (`admin` / `xpto` / default AP secret) with first-boot forced change flow. File: `include/Constants.h`
@@ -69,6 +68,10 @@ Current version: 9.17-dev
 3. [x] Updated firmware version format support (example: `9.17-dev`).
 4. [x] Updated code/version reporting to use string `VERSION`.
 5. [x] Improved `extra_script.py` handling for quoted `VERSION` values.
+
+## Security & API
+
+1. [x] Converted state-changing endpoints to support `POST` (`/reboot`, `/load-defaults`, `/templates/change`) and switched webpanel calls to `POST` while keeping temporary `GET` compatibility. Files: `src/WebServer.cpp`, `webpanel/js/index.js`
 
 ## Quick Release Flow
 

--- a/VERSION_INFO.md
+++ b/VERSION_INFO.md
@@ -18,6 +18,7 @@ cleaner build flags, and consistent firmware version reporting.
 - Firmware: use `String(VERSION)` for API, mDNS, and Home Assistant firmware metadata. - 11.02.2026
 - Build script: improve `tools/extra_script.py` parsing for quoted `VERSION` values. - 11.02.2026
 - Git: keep `platformio_override.ini` ignored as a local-only file. - 11.02.2026
+- Security/API: switched state-changing endpoints to `POST` (`/reboot`, `/load-defaults`, `/templates/change`); webpanel now calls `POST` and backend keeps temporary `GET` compatibility. - 13.02.2026
 
 ### Version 9.163 - Stable Release
 - Baseline before `9.17-dev` maintenance and build-flow updates. - 

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -324,10 +324,8 @@ void loadAPI()
     response->setLength();
     request->send(response); }));
 
-  /*REBOOT DEVICE*/
-  server
-      .on("/reboot", HTTP_GET, [](AsyncWebServerRequest *request)
-          {
+  auto rebootHandler = [](AsyncWebServerRequest *request)
+  {
 #if WEB_SECURE_ON
     if (!request->authenticate(config.apiUser, config.apiPassword, REALM))
       return request->requestAuthentication(REALM);
@@ -337,27 +335,39 @@ void loadAPI()
     root["result"] = "Reboot requested";
     response->setLength();
     request->send(response);
-    config.requestRestart(); });
+    config.requestRestart();
+  };
 
-  /*CHANGE FEATURES TEMPLATE*/
-  server
-      .on("/templates/change", HTTP_GET, [](AsyncWebServerRequest *request)
-          {
+  auto templateChangeHandler = [](AsyncWebServerRequest *request)
+  {
 #if WEB_SECURE_ON
     if (!request->authenticate(config.apiUser, config.apiPassword, REALM))
       return request->requestAuthentication(REALM);
 #endif
+    AsyncWebParameter *templateParam = nullptr;
+    if (request->hasParam("t", true))
+      templateParam = request->getParam("t", true);
+    else if (request->hasParam("t"))
+      templateParam = request->getParam("t");
+
+    if (templateParam == nullptr)
+    {
+      request->send(errorResponse("Template id is missing"));
+      return;
+    }
+
+    templateSelect((Template)templateParam->value().toInt());
+    config.save();
+
     AsyncJsonResponse *response = new AsyncJsonResponse();
     JsonVariant &root = response->getRoot();
     root["result"] = "Template changed";
     response->setLength();
     request->send(response);
-    templateSelect((Template)request->getParam("t")->value().toInt());
-    config.save(); });
+  };
 
-  server
-      .on("/load-defaults", HTTP_GET, [](AsyncWebServerRequest *request)
-          {
+  auto loadDefaultsHandler = [](AsyncWebServerRequest *request)
+  {
 #if WEB_SECURE_ON
     if (!request->authenticate(config.apiUser, config.apiPassword, REALM))
       return request->requestAuthentication(REALM);
@@ -367,7 +377,19 @@ void loadAPI()
     root["result"] = "Load defaults requested";
     response->setLength();
     request->send(response);
-    config.requestLoadDefaults(); });
+    config.requestLoadDefaults();
+  };
+
+  // POST is the preferred method for state-changing endpoints.
+  // Keep GET temporarily for backward compatibility with old clients.
+  server.on("/reboot", HTTP_POST, rebootHandler);
+  server.on("/reboot", HTTP_GET, rebootHandler);
+
+  server.on("/templates/change", HTTP_POST, templateChangeHandler);
+  server.on("/templates/change", HTTP_GET, templateChangeHandler);
+
+  server.on("/load-defaults", HTTP_POST, loadDefaultsHandler);
+  server.on("/load-defaults", HTTP_GET, loadDefaultsHandler);
 
   server
       .on("/auto-update", HTTP_POST, [](AsyncWebServerRequest *request)

--- a/webpanel/js/index.js
+++ b/webpanel/js/index.js
@@ -602,6 +602,7 @@ async function backup() {
 
 function reboot() {
     fetch(baseUrl + "/reboot", {
+        method: "POST",
         headers: {
             'Content-Type': 'text/plain; charset=utf-8',
             'Accept': 'application/json'
@@ -630,6 +631,7 @@ function reboot() {
 
 function loadDefaults() {
     fetch(baseUrl + "/load-defaults", {
+        method: "POST",
         headers: {
             'Content-Type': 'text/plain; charset=utf-8',
             'Accept': 'application/json'


### PR DESCRIPTION
(cherry picked from commit b8fbb900c33d06799ff4133649f64333ff32c4ad)

## Summary
Harden state-changing API actions by using `POST` instead of `GET`, while keeping temporary backward compatibility for existing clients.

## Changes
- `src/WebServer.cpp`
  - Added `POST` handlers for:
    - `/reboot`
    - `/load-defaults`
    - `/templates/change`
  - Kept `GET` handlers temporarily for compatibility.
  - Added guard for missing template parameter `t` to avoid invalid requests.

- `webpanel/js/index.js`
  - Switched `reboot()` request to `POST`.
  - Switched `loadDefaults()` request to `POST`.

- `TODO_IMPROVEMENTS.md`
  - Marked the GET->POST endpoint migration as completed.

- `VERSION_INFO.md`
  - Added release note entry for POST endpoint hardening.

## Validation
- Device/app flow tested after flashing: behavior remains OK.
- This is a low-risk security hardening change with compatibility preserved.
