### PR TITLE
docs: sync changelog/todo for cloudio https stabilization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## [9.17] - 2026-02-14
+
+### Release
+- Promoted stable release from `9.17-dev`.
+- Includes CloudIO/webpanel/build-flow improvements from the 9.17 development cycle.
+- Added `## [9.17]` release section to satisfy strict release validation checks.
+- Verified all configured PlatformIO environments build successfully for the 9.17 release snapshot.
+
 ## [9.17-dev] - 2026-02-12
 
 ### Build and Versioning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project are documented in this file.
 - Normalized firmware version in cloud config payload (strip `-dev` suffix for backend compatibility).
 - Updated CloudIO config request to use secure client for HTTPS and added one-time silent HTTP fallback on connection/TLS failure to prevent restart loops (`src/CloudIO.cpp`).
 - Kept serial logs clean by removing fallback/URL noise while preserving request status output (`src/CloudIO.cpp`).
+- Validated OTA update flow over HTTPS on ESP8266 (`Update Success`) with successful reconnect to CloudIO/MQTT after reboot.
 
 ### Webpanel
 - Replaced `parseFloat` version compare with robust parser/comparator for `-dev` formats.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [9.17-dev] - 2026-02-12
+
+### Build and Versioning
+- Added support for local overrides via `platformio_override.ini`.
+- Added `${extra.wifi_flags}` injection so local Wi-Fi settings stay out of git.
+- Switched version define to string format: `VERSION='"${extra.version}"'`.
+- Updated firmware reporting to use `String(VERSION)` for API, mDNS, and Home Assistant metadata.
+- Improved `tools/extra_script.py` parsing for quoted `VERSION` values.
+- Kept `platformio_override.ini` ignored as a local-only file.
+- Added `tools/validate_release.sh` for pre-release metadata validation (version, changelog, release envs, OTA/config URL checks).
+- Added automatic pre-build hooks in `tools/extra_script.py`:
+  - run `tools/html_converter.sh`
+  - run `tools/validate_release.sh`
+- Added skip toggles in `platformio.ini`:
+  - `SKIP_HTML_CONVERT`
+  - `SKIP_RELEASE_VALIDATE`
+- Enforced `WEB_SECURE_ON` in production/non-debug profiles and removed debug defaults from release builds (`platformio.ini`).
+- Automated webpanel asset cache token versioning during HTML conversion using project version (`[extra] version`), removing manual hardcoded `?v=` updates.
+
+### Security
+- Stopped logging credential values in debug output (`src/CoreWiFi.cpp`, `src/ConfigOnofre.cpp`).
+- Switched state-changing API routes to `POST` (`/reboot`, `/load-defaults`, `/templates/change`) and updated webpanel calls; temporary `GET` compatibility remains for older clients.
+- Migrated CloudIO config and OTA endpoints from `http://` to `https://` in firmware constants (`include/Constants.h`).
+
+### CloudIO
+- Normalized firmware version in cloud config payload (strip `-dev` suffix for backend compatibility).
+- Updated CloudIO config request to use secure client for HTTPS and added one-time silent HTTP fallback on connection/TLS failure to prevent restart loops (`src/CloudIO.cpp`).
+- Kept serial logs clean by removing fallback/URL noise while preserving request status output (`src/CloudIO.cpp`).
+
+### Webpanel
+- Replaced `parseFloat` version compare with robust parser/comparator for `-dev` formats.
+- Removed hardcoded API base URL and switched to same-origin requests.
+
+### Code Quality
+- Replaced deprecated ArduinoJson `containsKey()` checks with `isNull()` guards in config update flow.
+- Added explicit ESP8266 no-op switch cases for ESP32-only drivers (`TMF882X`, `LD2410`) to clear switch warnings.
+
+### Process and Release
+- Added `docs/RELEASE_WORKFLOW.md` with CP/PR workflow steps.
+- Added branch naming convention for CP branches.
+- Added release checklist in repo docs.
+- Added `tools/generate_release_notes.sh` to create `RELEASE_NOTES_DRAFT.md` from git history.
+
+## [9.163] - Stable baseline
+
+- Baseline before `9.17-dev` maintenance and build-flow updates.

--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -16,7 +16,7 @@ Current version: 9.17-dev
 ## Security & OTA (P1)
 
 1. [ ] Remove temporary CloudIO HTTP fallback after full TLS compatibility is confirmed on devices. File: `src/CloudIO.cpp`
-2. [ ] Validate OTA update flow over HTTPS on real devices/variants. File: `src/WebServer.cpp`
+2. [ ] Validate OTA update flow over HTTPS on remaining device variants (ESP32 / ESP32C3 / HAN). File: `src/WebServer.cpp`
 
 ## Webpanel UX (P1/P2)
 
@@ -51,6 +51,7 @@ Current version: 9.17-dev
 2. [x] Migrated CloudIO config and OTA endpoints from `http://` to `https://` and validated runtime behavior on device. Files: `include/Constants.h`, `src/CloudIO.cpp`, `src/WebServer.cpp`
 3. [x] Converted state-changing endpoints from GET to POST (`/reboot`, `/load-defaults`, `/templates/change`). File: `src/WebServer.cpp`
 4. [x] Added HTTPS-first CloudIO config request with one-time silent HTTP fallback to prevent restart loops when TLS path fails. File: `src/CloudIO.cpp`
+5. [x] Validated OTA update flow over HTTPS on ESP8266 (`Update Success` + reconnect to CloudIO/MQTT). File: `src/WebServer.cpp`
 
 ## Webpanel
 

--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -1,7 +1,7 @@
 # EasyIot - To Do
 
 Created by: Alexandru Hauzman  
-Updated: 11.02.2026  
+Updated: 14.02.2026  
 Current version: 9.17-dev
 
 ## Important Notes
@@ -13,50 +13,20 @@ Current version: 9.17-dev
 
 ## Firmware & Versioning (P1)
 
-1. [ ] Fix firmware version compare in webpanel for `-dev` formats (replace `parseFloat` logic). File: `webpanel/js/index.js`
-2. [ ] Add version/OTA metadata validation before release.
-3. [ ] Add `CHANGELOG.md` with version-by-version entries.
-
 ## Security & OTA (P1)
 
-1. [ ] Move cloud config/OTA URLs from `http://` to secure transport and validate update path. File: `include/Constants.h`
-2. [ ] Remove Wi-Fi password from debug logs (never print secrets). File: `src/CoreWiFi.cpp`
-3. [ ] Convert state-changing endpoints from GET to POST (`/reboot`, `/load-defaults`, `/templates/change`). File: `src/WebServer.cpp`
-4. [ ] Ensure release profiles enforce `WEB_SECURE_ON` and avoid debug defaults in production builds. File: `platformio.ini`
-5. [ ] Remove password logging for AP/API changes in debug logs. File: `src/ConfigOnofre.cpp`
-6. [ ] Replace default credentials (`admin` / `xpto` / default AP secret) with first-boot forced change flow. File: `include/Constants.h`
-7. [ ] Change captive portal save flow from GET query params to POST body (avoid leaking passwords in URL/history). Files: `include/CaptivePortal.h`, `src/WebServer.cpp`
-8. [ ] Add OTA integrity check (signed firmware or hash validation) before applying update. File: `src/WebServer.cpp`
-
-## Dependencies & Library Updates (P1/P2)
-
-1. [ ] Pin PlatformIO platforms to known-good versions (`espressif32@...`, `espressif8266@...`) for reproducible builds. File: `platformio.ini`
-2. [ ] Pin GitHub-based `lib_deps` to tags/commits (avoid floating `master/main`). File: `platformio.ini`
-3. [ ] Add periodic dependency audit task (`pio pkg outdated` + compatibility notes per env).
-4. [ ] Create dependency update policy doc (how to test + rollback by env).
-5. [ ] Normalize `lib_deps` formatting and identifiers (remove ambiguous specs / spacing inconsistencies). File: `platformio.ini`
+1. [ ] Remove temporary CloudIO HTTP fallback after full TLS compatibility is confirmed on devices. File: `src/CloudIO.cpp`
+2. [ ] Validate OTA update flow over HTTPS on real devices/variants. File: `src/WebServer.cpp`
 
 ## Webpanel UX (P1/P2)
 
-1. [ ] Remove hardcoded `baseUrl` and use same-origin requests. File: `webpanel/js/index.js`
-2. [ ] Add automatic version banner in webpanel footer.
-3. [ ] Add firmware build date in API/system info payload.
-4. [ ] Avoid external hard dependency for core UI assets (icons/fonts) by hosting fallback assets locally. Files: `webpanel/index.html`, `webpanel/js/index.js`
+1. [ ] Add firmware build date in API/system info payload.
 
 ## Testing & CI (P2)
 
 1. [ ] Add CI build checks for main envs (ESP8266 + ESP32).
 2. [ ] Add smoke tests for boot, Wi-Fi, MQTT, OTA update path.
 3. [ ] Add quick rollback notes for failed release/update.
-4. [ ] Add CI checks for formatting/sanity of `platformio.ini` (flags, env inheritance, unsafe defaults).
-
-## Process & Release (P2)
-
-1. [ ] Add a short PR workflow guide (development -> cherry-pick branch -> upstream PR).
-2. [ ] Add branch naming convention for external PRs.
-3. [ ] Add a release checklist document in repo docs.
-4. [ ] Add a small script to prepare release notes draft.
-5. [ ] Add pre-release checklist item for credential and transport-security review.
 
 #
 
@@ -69,6 +39,36 @@ Current version: 9.17-dev
 3. [x] Updated firmware version format support (example: `9.17-dev`).
 4. [x] Updated code/version reporting to use string `VERSION`.
 5. [x] Improved `extra_script.py` handling for quoted `VERSION` values.
+6. [x] Added `CHANGELOG.md` as the single release-history file.
+7. [x] Added pre-release metadata validator (version/changelog/env/OTA URL checks). File: `tools/validate_release.sh`
+8. [x] Added automatic pre-build hooks for HTML conversion and release validation with skip flags. Files: `tools/extra_script.py`, `platformio.ini`
+9. [x] Enforced `WEB_SECURE_ON` for production/non-debug profiles and removed debug defaults from release builds. File: `platformio.ini`
+10. [x] Automated webpanel asset cache version (`?v=`) from project version during build conversion (no manual hardcoded value updates). Files: `webpanel/index.html`, `tools/html_converter.sh`
+
+## Security
+
+1. [x] Stopped logging credential values in debug output (`src/CoreWiFi.cpp`, `src/ConfigOnofre.cpp`).
+2. [x] Migrated CloudIO config and OTA endpoints from `http://` to `https://` and validated runtime behavior on device. Files: `include/Constants.h`, `src/CloudIO.cpp`, `src/WebServer.cpp`
+3. [x] Converted state-changing endpoints from GET to POST (`/reboot`, `/load-defaults`, `/templates/change`). File: `src/WebServer.cpp`
+4. [x] Added HTTPS-first CloudIO config request with one-time silent HTTP fallback to prevent restart loops when TLS path fails. File: `src/CloudIO.cpp`
+
+## Webpanel
+
+1. [x] Fixed firmware version comparison for `-dev` formats (replaced `parseFloat` logic). File: `webpanel/js/index.js`
+2. [x] Removed hardcoded `baseUrl` and switched to same-origin requests. File: `webpanel/js/index.js`
+3. [x] Added automatic firmware version display in webpanel footer (`version_lbl` from `/config`). Files: `webpanel/index.html`, `webpanel/js/index.js`
+
+## Code Quality
+
+1. [x] Replaced deprecated ArduinoJson `containsKey()` checks in config update path with `isNull()` guards. File: `src/ConfigOnofre.cpp`
+2. [x] Added explicit ESP8266 no-op switch cases for ESP32-only sensor drivers (`TMF882X`, `LD2410`) to remove compiler switch warnings. File: `src/Sensors.cpp`
+
+## Process & Release
+
+1. [x] Added PR workflow guide (development -> cherry-pick branch -> upstream PR). File: `docs/RELEASE_WORKFLOW.md`
+2. [x] Added branch naming convention for external CP branches. File: `docs/RELEASE_WORKFLOW.md`
+3. [x] Added release checklist document in repo docs. File: `docs/RELEASE_WORKFLOW.md`
+4. [x] Added script to generate release notes draft from commits. File: `tools/generate_release_notes.sh`
 
 ## Quick Release Flow
 

--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -44,6 +44,7 @@ Current version: 9.17-dev
 8. [x] Added automatic pre-build hooks for HTML conversion and release validation with skip flags. Files: `tools/extra_script.py`, `platformio.ini`
 9. [x] Enforced `WEB_SECURE_ON` for production/non-debug profiles and removed debug defaults from release builds. File: `platformio.ini`
 10. [x] Automated webpanel asset cache version (`?v=`) from project version during build conversion (no manual hardcoded value updates). Files: `webpanel/index.html`, `tools/html_converter.sh`
+11. [x] Resolved strict release-validation mismatch for `9.17` by adding matching changelog header and confirmed full all-env build pass for release snapshot.
 
 ## Security
 


### PR DESCRIPTION
(cherry picked from commit fff929ee32a037bc4d950ae1367125427336f88c)

## What changed
- Synced `TODO_IMPROVEMENTS.md` with current implementation status.
- Added/updated completed security items:
  - CloudIO/OTA URL migration to HTTPS
  - GET -> POST change for state-changing endpoints
  - HTTPS-first CloudIO request with silent HTTP fallback
- Added follow-up backlog items for next phase:
  - remove temporary fallback after full TLS validation
  - validate OTA update flow over HTTPS on real devices/variants
- Added/updated matching `CHANGELOG.md` entries for CloudIO HTTPS stabilization and logging cleanup.

## Why
Docs were behind real firmware behavior after recent CloudIO HTTPS stabilization work.  
This PR brings changelog + todo in sync so release/PR tracking is accurate.

## Scope
Docs only:
- `CHANGELOG.md`
- `TODO_IMPROVEMENTS.md`
