### PR TITLE
Cp config builddate api

### DIFF
--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -43,12 +43,13 @@ Current version: 9.17-dev
 3. [ ] Add firmware build date in API/system info payload.
 4. [ ] Avoid external hard dependency for core UI assets (icons/fonts) by hosting fallback assets locally. Files: `webpanel/index.html`, `webpanel/js/index.js`
 
-## Testing & CI (P2)
+## Testing & CI (P2 - Deferred / Later)
 
-1. [ ] Add CI build checks for main envs (ESP8266 + ESP32).
-2. [ ] Add smoke tests for boot, Wi-Fi, MQTT, OTA update path.
-3. [ ] Add quick rollback notes for failed release/update.
-4. [ ] Add CI checks for formatting/sanity of `platformio.ini` (flags, env inheritance, unsafe defaults).
+- Deferred by owner for now (no Git CI setup in current phase).
+1. [ ] (Deferred) Add CI build checks for main envs (ESP8266 + ESP32).
+2. [ ] (Deferred) Add smoke tests for boot, Wi-Fi, MQTT, OTA update path.
+3. [ ] (Deferred) Add quick rollback notes for failed release/update.
+4. [ ] (Deferred) Add CI checks for formatting/sanity of `platformio.ini` (flags, env inheritance, unsafe defaults).
 
 ## Process & Release (P2)
 

--- a/src/ConfigOnofre.cpp
+++ b/src/ConfigOnofre.cpp
@@ -9,6 +9,9 @@
 #include "Images.hpp"
 #include <PZEM004Tv30.h>
 #include "HomeAssistantMqttDiscovery.h"
+
+static constexpr const char *kFirmwareBuildDate = __DATE__ " " __TIME__;
+
 void actuatoresCallback(message_t const &msg, void *arg);
 void ConfigOnofre::generateId(String &id, const String &name, int familyCode, int io, size_t maxSize)
 {
@@ -642,6 +645,7 @@ void ConfigOnofre::json(JsonVariant &root, bool allFields)
   root["wifiMask"] = WiFi.subnetMask().toString();
   root["wifiGw"] = WiFi.gatewayIP().toString();
   root["firmware"] = String(VERSION);
+  root["buildDate"] = kFirmwareBuildDate;
 #ifdef ESP32
 #ifdef ESP32_MAKER_4MB
   root["mcu"] = "ESP32-MAKER-4MB";

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -289,8 +289,10 @@ void loadAPI()
     AsyncJsonResponse *response = new AsyncJsonResponse();
     JsonVariant &root = response->getRoot();
     config.json(root,true);
-    response->setLength();
-    request->send(response); });
+    String payload;
+    serializeJsonPretty(root, payload);
+    delete response;
+    request->send(200, "application/json", payload); });
 
   /*SAVE CONFIG*/
   server


### PR DESCRIPTION
## Summary
Add firmware build metadata and improve readability for the `/config` API response.

## Changes
- Add compile-time build timestamp constant using `__DATE__` + `__TIME__`.
- Expose new `buildDate` field in `ConfigOnofre::json(...)` payload.
- Return pretty-printed (multi-line) JSON from `GET /config` for easier inspection.

## Why
This makes it easier to verify exactly which firmware binary is running after OTA/manual updates, and improves API readability directly in browser/tools without extra formatting.

## Validation
- Built successfully locally:
  - `platformio run -e ESP8266_DEBUG`
- Confirmed `/config` now:
  - includes `"buildDate": "<compile date time>"`
  - is returned as readable multi-line JSON

## Notes
- No webpanel UI changes in this PR.
- Payload fields remain compatible; this adds `buildDate` and changes response formatting only.
{
  "nodeId": "dev",
  "chipId": "xxxxx",
  "mqttIpDns": "",
  "mqttPort": xxxx,
  "mqttUsername": "",
  "apiUser": "admin",
  "wifiSSID": "xxxxx",
  "dhcp": true,
  "mqttConnected": false,
  "wifiIp": "xxxxxx,
  "wifiMask": "xxxxx,
  "wifiGw": "xxxxx,
  "firmware": "9.17-dev",
  "buildDate": "Feb 14 2026 18:30:03",
  "mcu": "ESP8266",
  "mac": "C8:2B:96:00:55:7A",
  "signal": -86,
  
 