### PR TITLE
Cp serial monitor polish

### DIFF
--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -1,7 +1,7 @@
 # EasyIot - To Do
 
 Created by: Alexandru Hauzman  
-Updated: 13.02.2026  
+Updated: 16.02.2026  
 Current version: 9.17-dev
 
 ## Important Notes
@@ -48,6 +48,7 @@ Current version: 9.17-dev
 ## Security
 
 1. [x] Stopped logging credential values in debug output (`src/CoreWiFi.cpp`, `src/ConfigOnofre.cpp`).
+2. [x] Validated OTA update flow over HTTPS on ESP32 (`Update Success` + reboot + reconnect to CloudIO/MQTT; `HTTPS result: 200`, `fallback=0`). File: `src/WebServer.cpp`
 
 ## Webpanel
 

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -42,6 +42,7 @@ namespace Payloads
 namespace tags
 {
     constexpr const char *system{"[SYSTEM]"};
+    constexpr const char *build{"[BUILD]"};
     constexpr const char *config{"[CONFIG]"};
     constexpr const char *mqtt{"[MQTT]"};
     constexpr const char *wifi{"[WIFI]"};

--- a/platformio.ini
+++ b/platformio.ini
@@ -195,6 +195,10 @@ build_unflags=
 [env:ESP8266_DEBUG]
 extends = ESP8266
 board_build.f_cpu = 160000000L
+monitor_speed=74880
+build_flags =
+    ${ESP8266.build_flags}
+    -D DEBUG_SERIAL_BAUD=74880
 build_unflags=
     -D WEB_SECURE_ON
     -D TEST_TEMPLATE

--- a/src/CloudIO.cpp
+++ b/src/CloudIO.cpp
@@ -58,6 +58,7 @@ void onMqttConnect(bool sessionPresent)
 {
 #ifdef DEBUG_ONOFRE
   Log.warning("%s Connected to MQTT." CR, tags::cloudIO);
+  Log.info("----------------------------------------------" CR);
 #endif
   mqttClient.publish(config.cloudIOhealthTopic, 0, true, "1\0");
   subscribeOnMqttCloudIO(config.cloudIOwriteTopic);
@@ -92,6 +93,7 @@ void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties 
   char msg[len + 1];
   strlcpy(msg, payload, sizeof(msg));
 #ifdef DEBUG_ONOFRE
+  Log.info("----------------------------------------------" CR);
   Log.info("%s Message from MQTT. %s %s" CR, tags::cloudIO, topic, msg);
 #endif
   if (strcmp(topic, config.cloudIOwriteTopic) == 0)
@@ -257,7 +259,8 @@ void connectToCloudIO()
   doc.clear();
   config.cloudIOReady = false;
 #ifdef DEBUG_ONOFRE
-  Log.info("%s [HTTP]  Request result: %d" CR, tags::cloudIO, httpCode);
+  Log.info("%s [HTTP] Request result: %d (fallback=%d)" CR, tags::cloudIO, httpCode, usedHttpFallback ? 1 : 0);
+  Log.info("----------------------------------------------" CR);
 #endif
   if (httpCode == HTTP_CODE_NO_CONTENT)
   {

--- a/src/CloudIO.cpp
+++ b/src/CloudIO.cpp
@@ -183,7 +183,7 @@ void connectToCloudIO()
   if (!wifiConnected())
   {
 #ifdef DEBUG_ONOFRE
-    Log.error("%s WIFI DISCONECTED" CR, tags::cloudIO);
+    Log.error("%s WIFI DISCONNECTED" CR, tags::cloudIO);
 #endif
     return;
   }

--- a/src/ConfigOnofre.cpp
+++ b/src/ConfigOnofre.cpp
@@ -218,11 +218,11 @@ ConfigOnofre &ConfigOnofre::load()
   {
     chipIdHex |= ((ESP.getEfuseMac() >> (40 - i)) & 0xff) << i;
   }
-  templateId = doc["templateId"];
   strlcpy(chipId, String(chipIdHex).c_str(), sizeof(chipId));
   sprintf(provisionId, "ONOFRE%s", chipId);
 
 #endif
+  templateId = doc["templateId"] | 0;
   strlcpy(nodeId,
           doc["nodeId"] | chipId,
           sizeof(nodeId));

--- a/src/CoreWiFi.cpp
+++ b/src/CoreWiFi.cpp
@@ -180,7 +180,7 @@ void infoWifi()
   {
     connectedOn = millis();
 #ifdef DEBUG_ONOFRE
-    Log.notice("%s MODE STA -------------------------------------" CR, tags::wifi);
+    Log.notice("%s MODE STA" CR, tags::wifi);
     Log.notice("%s SSID  %s  " CR, tags::wifi, WiFi.SSID().c_str());
     Log.notice("%s CH    %d   " CR, tags::wifi, WiFi.channel());
     Log.notice("%s RSSI  %d " CR, tags::wifi, WiFi.RSSI());
@@ -197,7 +197,7 @@ void infoWifi()
   if (WiFi.getMode() & WIFI_AP)
   {
 #ifdef DEBUG_ONOFRE
-    Log.notice("%s MODE AP --------------------------------------" CR, tags::wifi);
+    Log.notice("%s MODE AP" CR, tags::wifi);
     Log.notice("%s SSID %s " CR, tags::wifi, jw.getAPSSID().c_str());
     Log.notice("%s IP  %s  " CR, tags::wifi, WiFi.softAPIP().toString().c_str());
     Log.notice("%s MAC  %s " CR, tags::wifi, WiFi.softAPmacAddress().c_str());

--- a/src/CoreWiFi.cpp
+++ b/src/CoreWiFi.cpp
@@ -254,11 +254,17 @@ void infoCallback(justwifi_messages_t code, char *parameter)
     knx.start();
     config.requestCloudIOSync();
     config.startCloudIOWatchdog();
+#ifdef DEBUG_ONOFRE
+    Log.notice("----------------------------------------------" CR);
+#endif
     infoWifi();
     break;
 
   case MESSAGE_ACCESSPOINT_CREATED:
     config.stopCloudIOWatchdog();
+#ifdef DEBUG_ONOFRE
+    Log.notice("----------------------------------------------" CR);
+#endif
     infoWifi();
     setupCaptivePortal();
     startWebserver();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,15 +9,101 @@
 #ifdef ESP32
 #include "nvs_flash.h"
 #include "driver/adc.h"
+#include "esp_system.h"
 #endif
 ConfigOnofre config;
+
+#ifdef DEBUG_ONOFRE
+namespace
+{
+#ifdef ESP32
+const char *esp32ResetReasonToText(esp_reset_reason_t reason)
+{
+  switch (reason)
+  {
+  case ESP_RST_POWERON:
+    return "Power-on";
+  case ESP_RST_EXT:
+    return "External reset";
+  case ESP_RST_SW:
+    return "Software reset";
+  case ESP_RST_PANIC:
+    return "Exception/Panic";
+  case ESP_RST_INT_WDT:
+    return "Interrupt watchdog";
+  case ESP_RST_TASK_WDT:
+    return "Task watchdog";
+  case ESP_RST_WDT:
+    return "Other watchdog";
+  case ESP_RST_DEEPSLEEP:
+    return "Deep sleep wake";
+  case ESP_RST_BROWNOUT:
+    return "Brownout";
+  case ESP_RST_SDIO:
+    return "SDIO reset";
+  default:
+    return "Unknown";
+  }
+}
+#endif
+
+const char *webSecureState()
+{
+#if defined(WEB_SECURE_ON)
+  return "on";
+#else
+  return "off";
+#endif
+}
+
+const char *langDefault()
+{
+#if defined(CONFIG_LANG_PT)
+  return "pt";
+#else
+  return "en";
+#endif
+}
+
+String resetReasonText()
+{
+#ifdef ESP8266
+  return ESP.getResetReason();
+#else
+  return String(esp32ResetReasonToText(esp_reset_reason()));
+#endif
+}
+
+void logBootBanner()
+{
+  const String firmwareVersion = String(VERSION);
+  const String resetReason = resetReasonText();
+
+  Log.info("----------------------------------------------" CR);
+  Log.info("%s Reset reason: %s" CR, tags::system, resetReason.c_str());
+  Log.info("%s Firmware Version: %s" CR, tags::system, firmwareVersion.c_str());
+  Log.info("----------------------------------------------" CR);
+  Log.info("%s Device: %s" CR, tags::build, config.nodeId);
+  Log.info("%s Version: %s" CR, tags::build, firmwareVersion.c_str());
+#ifdef ESP8266
+  Log.info("%s MCU: ESP8266" CR, tags::build);
+#else
+  Log.info("%s MCU: ESP32" CR, tags::build);
+#endif
+  Log.info("%s Mode: DEBUG" CR, tags::build);
+  Log.info("%s WEB_SECURE_ON: %s" CR, tags::build, webSecureState());
+  Log.info("%s Lang default: %s" CR, tags::build, langDefault());
+  Log.info("----------------------------------------------" CR);
+}
+} // namespace
+#endif
 
 void checkInternalRoutines()
 {
   if (config.isCloudIOSyncRequested())
   {
 #ifdef DEBUG_ONOFRE
-    Log.notice("%s CloudIO requested.", tags::system);
+    Log.notice("%s CloudIO requested." CR, tags::system);
 #endif
     connectToCloudIO();
   }
@@ -25,7 +111,7 @@ void checkInternalRoutines()
   if (config.isWifiScanRequested())
   {
 #ifdef DEBUG_ONOFRE
-    Log.notice("%sScan Network.", tags::system);
+    Log.notice("%s Scan Network." CR, tags::system);
 #endif
     scanNewWifiNetworks();
   }
@@ -33,7 +119,7 @@ void checkInternalRoutines()
   if (config.isRestartRequested())
   {
 #ifdef DEBUG_ONOFRE
-    Log.notice("%s Restart requested.", tags::system);
+    Log.notice("%s Restart requested." CR, tags::system);
 #endif
     delay(100);
     ESP.restart();
@@ -42,7 +128,7 @@ void checkInternalRoutines()
   if (config.isLoadDefaultsRequested())
   {
 #ifdef DEBUG_ONOFRE
-    Log.notice("%s Load Defaults requested.", tags::system);
+    Log.notice("%s Load Defaults requested." CR, tags::system);
 #endif
 #if defined(ESP32) && !defined(LEGACY_PROVISON)
     ESP_ERROR_CHECK(nvs_flash_erase());
@@ -60,7 +146,7 @@ void checkInternalRoutines()
   if (config.isAutoUpdateRequested())
   {
 #ifdef DEBUG_ONOFRE
-    Log.notice("%sAuto Update Request.", tags::system);
+    Log.notice("%s Auto Update Request." CR, tags::system);
 #endif
     config.pauseFeatures();
     stopWebserver();
@@ -70,7 +156,7 @@ void checkInternalRoutines()
   if (config.isReloadWifiRequested())
   {
 #ifdef DEBUG_ONOFRE
-    Log.notice("%s Loading wifi configuration...", tags::system);
+    Log.notice("%s Loading wifi configuration..." CR, tags::system);
 #endif
 #if defined(ESP8266) || defined(LEGACY_PROVISON)
     reloadWiFiConfig();
@@ -110,12 +196,19 @@ void featuresTask(void *pvParameters)
 void setup()
 {
 #ifdef DEBUG_ONOFRE
-  Serial.begin(115200);
+#ifndef DEBUG_SERIAL_BAUD
+#define DEBUG_SERIAL_BAUD 115200
+#endif
+  Serial.begin(DEBUG_SERIAL_BAUD);
+  Serial.println();
   Log.begin(LOG_LEVEL_VERBOSE, &Serial);
 #endif
 
   startFileSystem();
   config.load();
+#ifdef DEBUG_ONOFRE
+  logBootBanner();
+#endif
   setupWiFi();
   setupCors();
 #ifdef ESP32

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,6 +77,7 @@ String resetReasonText()
 void logBootBanner()
 {
   const String firmwareVersion = String(VERSION);
+  const String firmwareBuildDate = String(__DATE__ " " __TIME__);
   const String resetReason = resetReasonText();
 
   Log.info("----------------------------------------------" CR);
@@ -85,6 +86,7 @@ void logBootBanner()
   Log.info("----------------------------------------------" CR);
   Log.info("%s Device: %s" CR, tags::build, config.nodeId);
   Log.info("%s Version: %s" CR, tags::build, firmwareVersion.c_str());
+  Log.info("%s buildDate: %s" CR, tags::build, firmwareBuildDate.c_str());
 #ifdef ESP8266
   Log.info("%s MCU: ESP8266" CR, tags::build);
 #else
@@ -104,6 +106,7 @@ void checkInternalRoutines()
   {
 #ifdef DEBUG_ONOFRE
     Log.notice("%s CloudIO requested." CR, tags::system);
+    Log.info("----------------------------------------------" CR);
 #endif
     connectToCloudIO();
   }


### PR DESCRIPTION
## Summary
Polish ESP8266 debug serial monitor output for better readability and add a small config-load fix for template handling.

## Changes
  - Docs: update TODO_IMPROVEMENTS.md to record ESP32 OTA HTTPS validation and note remaining OTA variants (ESP32C3/HAN).
- Add build timestamp line to boot banner:
  - `[BUILD] buildDate: <compile date time>`
- Add visual separators around CloudIO flow:
  - after `[SYSTEM] CloudIO requested.`
  - after `[CLOUDIO] [HTTP] Request result: ...`
  - after `[CLOUDIO] Connected to MQTT.`
- Add separator before each incoming MQTT message log block.
- Add separator before Wi-Fi info blocks when entering:
  - `MESSAGE_CONNECTED`
  - `MESSAGE_ACCESSPOINT_CREATED`
- Fix `templateId` load on ESP8266 by loading it outside ESP32-only code path.

## Why
- Serial monitor is easier to scan during bring-up and cloud connectivity debugging.
- MQTT command bursts are now visually grouped.
- Prevents inconsistent template handling behavior on ESP8266 boots.

## Validation
- Built successfully:
  - `platformio run -e ESP8266_DEBUG -j1`
- Flashed and verified in serial monitor:
  - STA connect logs appear cleanly separated.
  - CloudIO request/response/MQTT phases are separated.
  - Incoming app MQTT commands are grouped with separators.
   - ESP32 OTA verified on device: Update Success, reboot, Wi-Fi reconnect, CloudIO HTTPS result 200 (fallback=0), MQTT reconnect.
## Example
```text
CONFIG] Stored config loaded.
I: ----------------------------------------------
I: [SYSTEM] Reset reason: External System
I: [SYSTEM] Firmware Version: 9.17-dev
I: ----------------------------------------------
I: [BUILD] Device: 917dev
I: [BUILD] Version: 9.17-dev
I: [BUILD] buildDate: Feb 15 2026 10:24:00
I: [BUILD] MCU: ESP8266
I: [BUILD] Mode: DEBUG
I: [BUILD] WEB_SECURE_ON: off
I: [BUILD] Lang default: pt
I: ----------------------------------------------
I: [MQTT] Setup
I: [SYSTEM] WEBSERVER START
I: [CLOUDIO] CloudIO Watchdog Started
I: ----------------------------------------------
I: [WIFI] MODE STA
I: [WIFI] SSID  .............
I: [WIFI] CH    11   
I: [WIFI] RSSI  -82 
I: [WIFI] IP    ........................ 
I: [WIFI] MAC  ......................
I: [WIFI] GW    ...................... 
I: [WIFI] MASK  ...................
I: [WIFI] DNS   ...................
I: [WIFI] HOST  917dev 
I: ----------------------------------------------
I: [SYSTEM] CloudIO requested.
I: ----------------------------------------------
W: [CLOUDIO] [HTTP] HTTPS attempt 1/3 failed: code=-1 error=connection failed rssi=-82
W: [CLOUDIO] [HTTP] HTTPS attempt 2/3 failed: code=-1 error=connection failed rssi=-82
W: [CLOUDIO] [HTTP] HTTPS attempt 3/3 failed: code=-1 error=connection failed rssi=-82
I: [CLOUDIO] [HTTP] HTTP attempt 1/1 result: 200
I: [CLOUDIO] [HTTP] Request result: 200 (fallback=1)
I: ----------------------------------------------
I: [CLOUDIO] SETUP MQTT CLOUD
E: [CLOUDIO] Ready to try...
E: [CLOUDIO] Connecting to MQTT...
W: [CLOUDIO] Connected to MQTT.
I: ----------------------------------------------