### PR TITLE
fix(build): pin PlatformIO platform versions

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -59,7 +59,7 @@ default_flags=
 
 
 [ESP32_C3]
-platform = espressif32
+platform = espressif32@6.4.0
 framework = arduino
 board = seeed_xiao_esp32c3
 board_build.mcu = esp32c3
@@ -82,7 +82,7 @@ lib_ignore = ESPAsyncTCP
 
 
 [ESP32_8M]
-platform = espressif32
+platform = espressif32@6.4.0
 board =  esp32dev
 framework = arduino
 board_build.flash_mode = qio
@@ -133,7 +133,7 @@ build_unflags=
     -D LEGACY_PROVISON
 
 [ESP8266]
-platform = espressif8266
+platform = espressif8266@4.2.1
 extra_scripts = pre:tools/extra_script.py
 board = esp12e
 framework = arduino


### PR DESCRIPTION
## Summary

Pin the PlatformIO platform versions used by the existing firmware so clean builds remain reproducible across ESP32, ESP32-C3, and ESP8266.

## Changes

- Pin both ESP32 base environments to `espressif32@6.4.0`.
- Pin the ESP8266 base environment to `espressif8266@4.2.1`.
- Keep the firmware version and runtime behavior unchanged.

## Why

The unpinned ESP32 platform now resolves to a newer pioarduino/Arduino core whose renamed Wi-Fi provisioning APIs make the current source fail to compile. A clean checkout can therefore break without any repository change. Pinning the known-good platform versions makes the source-to-binary toolchain deterministic.

## Validation

- `pio run -e ESP32C3_HAN` — pass; RAM 78,972 bytes (24.1%), flash 1,962,916 bytes (62.4%).
- `pio run -e ESP32_RELEASE` — pass; RAM 65,948 bytes (20.1%), flash 1,335,217 bytes (39.9%).
- `pio run -e ESP8266_RELEASE` — pass; RAM 42,376 bytes (51.7%), flash 680,293 bytes (65.1%).
- Release metadata validation — 0 failures and 0 warnings for the release builds.
- `git diff --check` — pass.

## Notes

- This PR changes build reproducibility only; it does not change firmware behavior.
- Git-based library dependencies that still track default branches are outside this PR.
- Hardware runtime testing was not required for the platform-line-only change.
