### PR TITLE
fix(han): harden silent-meter polling

### DIFF
--- a/src/ModbusMaster.cpp
+++ b/src/ModbusMaster.cpp
@@ -739,6 +739,10 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
       {
         _idle();
       }
+      // Let the Wi-Fi/TCP stack and watchdog run while a meter is silent or a
+      // partial response has stalled. This must be in the no-data branch: tying
+      // it to a particular ADU length leaves that exact length spinning.
+      yield();
 #if __MODBUSMASTER_DEBUG__
       digitalWrite(__MODBUSMASTER_DEBUG_PIN_B__, false);
 #endif
@@ -791,14 +795,6 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
         u8BytesLeft = 5;
         break;
       }
-    }
-    else
-    {
-      // Nothing to read yet. Without this the wait is a tight spin: on a meter
-      // that stops answering it holds the CPU for the full 2 s timeout, which
-      // starves the network stack and trips the ESP8266 software watchdog
-      // (~3.2 s) — the device resets and drops its MQTT session.
-      yield();
     }
     if ((millis() - u32StartTime) > ku16MBResponseTimeout)
     {

--- a/src/Sensors.cpp
+++ b/src/Sensors.cpp
@@ -441,11 +441,12 @@ void Sensor::loop()
       uint8_t rsl = modbus->readInputRegisters(CLOCK, 1);
       if (rsl == modbus->ku8MBSuccess)
       {
-        // The clock is six 16-bit words. Never index past the array: `available()`
-        // returns a count, so the loop must stop before it (it used to run one
-        // element too far and corrupt the stack).
+        // This bundled ModbusMaster stores the last valid response index rather
+        // than a word count. Add one, then clamp to the six-word clock buffer.
+        // Using `i < available()` here drops the final word.
         std::array<uint16_t, 6> buffer{};
-        const size_t words = std::min<size_t>(modbus->available(), buffer.size());
+        const size_t words = std::min<size_t>(
+            static_cast<size_t>(modbus->available()) + 1U, buffer.size());
         for (size_t i = 0; i < words; ++i)
         {
           buffer[i] = modbus->getResponseBuffer(i);
@@ -478,10 +479,8 @@ void Sensor::loop()
         {
           obj["status"] = "Erro desconhecido";
         }
-        // Stop the read cycle here. Every later read is guarded by `!error`, so
-        // leaving this out meant a meter that stopped answering was polled another
-        // seven times, each blocking for the full 2 s Modbus timeout — long enough
-        // for the watchdog to reset the device and drop its MQTT session.
+        // Stop the read cycle here. Without this, the next guarded read waits for
+        // another full Modbus timeout before it records the error.
         setError();
 #ifdef DEBUG_ONOFRE
         Log.info("%s HAN  Error: %d. " CR, tags::sensors, rsl);
@@ -559,9 +558,9 @@ void Sensor::loop()
         setError();
       }
 
-      if (modbus->readLastProfile(0x06, 0x01) == modbus->ku8MBSuccess)
+      if (!error && modbus->readLastProfile(0x06, 0x01) == modbus->ku8MBSuccess)
       {
-        std::array<uint16_t, 6> buffer;
+        std::array<uint16_t, 6> buffer{};
         for (size_t i = 0; i <= 3; ++i)
         {
           buffer[i] = modbus->getResponseBuffer(i);


### PR DESCRIPTION
## Summary

Harden HAN Modbus polling when the meter is silent or returns a partial response, while preserving every returned clock word under the current ModbusMaster buffer semantics.

## Changes

- Yield whenever the serial stream has no available byte, including a response stalled at exactly five bytes.
- Zero-initialize the six-word HAN clock buffer.
- Treat `available()` as the current implementation defines it: the last valid response-buffer index, then clamp the derived word count to the destination size.
- Skip the last-profile request after an earlier read has already failed.
- Correct the timeout explanation in the source comment.

## Why

The previous yield was attached to the frame-size check, so a five-byte partial response could still busy-spin. The new upstream clock loop also used `i < available()`, but this bundled ModbusMaster stores the last valid index rather than a count; that dropped the final word and copied zero words for a one-word response. Finally, the unguarded profile request could add another blocking timeout after a known failure.

## Validation

- `pio run -e ESP8266-HAN_RELEASE` — pass on v9.168; RAM 42,456 bytes (51.8%), flash 681,037 bytes (65.2%).
- Release metadata validation — 0 failures and 0 warnings.
- `git diff --check` — pass.

## Notes

- The `available() + 1` handling intentionally matches the current last-index semantics. It must be removed if ModbusMaster is later changed to return a true count.
- The existing policy that requests a device restart after repeated HAN failures is not changed here.
- Silent-meter and partial-frame behavior still needs verification on real HAN hardware.
