### PR TITLE
feat(tools): preserve local firmware binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 platformio_override.ini
 .vscode
 RELEASE_NOTES_DRAFT.md
+/firmware_bins/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,19 @@ O projeto EasyIot, é o firmware oficial para todas as boards OnOfre, no entanto
 - Configurar o `Wi-Fi broker`, `MQTT broker` entre outras coisas como integração automática com `Home Assistant`
 - E tá feito, agora é só curtir :) 
 
+## Binários locais de firmware
+
+Depois de compilar com PlatformIO, `tools/export_firmware.py` pode guardar o
+binário como candidato local, verificá-lo com SHA-256 e, após teste na board,
+preservá-lo como uma versão conhecida e funcional. A pasta gerada
+`firmware_bins/` é local e ignorada pelo Git.
+
+Os ambientes com `DEBUG` ou `RELEASE` no nome guardam automaticamente o seu
+candidato no fim de uma compilação bem-sucedida.
+
+Consulte [docs/RELEASE_WORKFLOW.md](docs/RELEASE_WORKFLOW.md#local-firmware-binaries)
+para os comandos de publicação, verificação e promoção.
+
 
 ## Donativos <a name="id6"></a>
 

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -51,15 +51,55 @@ This document defines the standard flow for development, upstream cherry-pick PR
 3. Never commit `platformio_override.ini`; it is intentionally ignored by Git.
 4. Keep `platformio.ini` free of real Wi-Fi credentials.
 
+## Local Firmware Binaries
+
+`tools/export_firmware.py` preserves disposable PlatformIO outputs under the
+ignored `firmware_bins/` directory. Each environment has its own candidate slot,
+so ESP8266, HAN, and ESP32 binaries cannot be confused.
+
+Successful environments whose names contain `DEBUG` or `RELEASE` publish their
+candidate automatically at the end of `platformio run`. This post-build step also
+runs when PlatformIO reuses an unchanged cached binary. Environments without an
+explicit channel in their name are not guessed; export those manually with
+`--channel debug` or `--channel release`.
+
+Build a development candidate:
+
+- `platformio run -e ESP8266_DEBUG`
+
+Build a release candidate:
+
+- `platformio run -e ESP8266_RELEASE`
+
+The equivalent manual publish command is:
+
+- `python tools/export_firmware.py publish --env ESP8266_DEBUG`
+
+Verify a candidate without modifying it:
+
+- `python tools/export_firmware.py verify --export-dir firmware_bins/candidate/debug/ESP8266_DEBUG --expected-env ESP8266_DEBUG`
+
+After that exact binary passes hardware testing, deliberately retain it as
+known-good firmware:
+
+- `python tools/export_firmware.py promote --candidate-dir firmware_bins/candidate/debug/ESP8266_DEBUG --hardware-tested-date today`
+
+Candidates are replaceable, but an existing known-good version is immutable: the
+tool refuses to overwrite it with different bytes or metadata. Every export has
+`BUILD_INFO.txt` and `SHA256SUMS.txt`. The ignored local directory is not an
+off-machine backup; archive important known-good firmware separately.
+
 ## Practical Notes
 
 - Prefer one CP per logical scope (security, webpanel, docs, etc.).
 - If a PR is closed or merged, delete local/remote CP branch to keep repo clean.
 - If `git cherry-pick --continue` fails due to editor, use:
   - `GIT_EDITOR=true git cherry-pick --continue`
-- Build hooks are automatic via `tools/extra_script.py`:
+- Build hooks are automatic via `tools/extra_script.py` and
+  `tools/post_extra_script.py`:
   - HTML converter runs before build
   - Release metadata validation runs before build
+  - Local DEBUG/RELEASE candidate export runs after a successful build
 - Optional skip defines in `platformio.ini` (`[extra] default_flags`):
   - `SKIP_HTML_CONVERT`
   - `SKIP_RELEASE_VALIDATE`

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,7 +67,7 @@ board_build.f_cpu = 160000000L
 monitor_speed=115200
 upload_speed=115200
 board_build.partitions = partitions_custom_c3.csv
-extra_scripts = pre:tools/extra_script.py
+extra_scripts = pre:tools/extra_script.py, post:tools/post_extra_script.py
 build_flags =
     ${extra.default_flags} 
     -DDYNAMIC_JSON_DOCUMENT_SIZE=3000 
@@ -90,7 +90,7 @@ board_upload.flash_size  = 8MB
 board_upload.maximum_size = 8388608
 monitor_filters = esp32_exception_decoder 
 monitor_speed=115200
-extra_scripts = pre:tools/extra_script.py
+extra_scripts = pre:tools/extra_script.py, post:tools/post_extra_script.py
 build_flags =
     ${extra.default_flags} 
     -DDYNAMIC_JSON_DOCUMENT_SIZE=3000 
@@ -134,7 +134,7 @@ build_unflags=
 
 [ESP8266]
 platform = espressif8266@4.2.1
-extra_scripts = pre:tools/extra_script.py
+extra_scripts = pre:tools/extra_script.py, post:tools/post_extra_script.py
 board = esp12e
 framework = arduino
 monitor_speed=115200

--- a/tools/export_firmware.py
+++ b/tools/export_firmware.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""Publish, verify, and promote local EasyIot firmware binaries."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date, datetime
+import hashlib
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import uuid
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT_ROOT = ROOT / "firmware_bins"
+EXPORT_MARKER = ".easyiot-firmware-export"
+CHECKSUM_PATTERN = re.compile(r"^([0-9a-f]{64})  ([^/\\]+)$")
+VERSION_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+){1,2}(?:-[A-Za-z0-9._-]+)?$")
+GENERATED_NAME_PATTERN = re.compile(r" - (\d{2}\.\d{2}\.\d{4})\.bin$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    publish_parser = commands.add_parser(
+        "publish", help="copy one PlatformIO binary into the current candidate slot"
+    )
+    publish_parser.add_argument("--env", required=True, help="PlatformIO environment")
+    publish_parser.add_argument(
+        "--channel",
+        choices=("debug", "release"),
+        help="inferred from an environment containing DEBUG or RELEASE when omitted",
+    )
+    publish_parser.add_argument(
+        "--bin", type=Path, help="explicit binary; otherwise locate it in .pio/build/<env>"
+    )
+    publish_parser.add_argument(
+        "--output-root", type=Path, default=DEFAULT_OUTPUT_ROOT
+    )
+    publish_parser.add_argument(
+        "--date", dest="date_stamp", help="build date in YYYY-MM-DD format"
+    )
+
+    verify_parser = commands.add_parser(
+        "verify", help="verify a candidate or known-good export without changing it"
+    )
+    verify_parser.add_argument("--export-dir", required=True, type=Path)
+    verify_parser.add_argument(
+        "--expected-channel", choices=("debug", "release")
+    )
+    verify_parser.add_argument("--expected-env")
+
+    promote_parser = commands.add_parser(
+        "promote", help="retain a hardware-tested candidate as an immutable known-good build"
+    )
+    promote_parser.add_argument("--candidate-dir", required=True, type=Path)
+    promote_parser.add_argument(
+        "--known-good-root",
+        type=Path,
+        default=DEFAULT_OUTPUT_ROOT / "known-good",
+    )
+    promote_parser.add_argument(
+        "--hardware-tested-date",
+        required=True,
+        help="test date in YYYY-MM-DD format, or 'today'",
+    )
+    return parser.parse_args()
+
+
+def parse_iso_date(value: str, *, label: str) -> date:
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError as error:
+        raise ValueError(f"{label} must use YYYY-MM-DD") from error
+
+
+def filename_token(value: str) -> str:
+    token = re.sub(r"[^A-Za-z0-9.+-]+", "_", value).strip("_")
+    if not token:
+        raise ValueError("value does not contain filename-safe characters")
+    return token
+
+
+def read_project_version(platformio_ini: Path = ROOT / "platformio.ini") -> str:
+    section = ""
+    for raw_line in platformio_ini.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            continue
+        if section == "extra" and re.match(r"^version\s*=", line):
+            version = line.split("=", 1)[1].split(";", 1)[0].split("#", 1)[0].strip()
+            if not VERSION_PATTERN.fullmatch(version):
+                raise ValueError(f"invalid [extra] version in {platformio_ini}: {version!r}")
+            return version
+    raise ValueError(f"could not read [extra] version from {platformio_ini}")
+
+
+def read_project_environments(platformio_ini: Path = ROOT / "platformio.ini") -> set[str]:
+    environments: set[str] = set()
+    for raw_line in platformio_ini.read_text(encoding="utf-8").splitlines():
+        match = re.fullmatch(r"\s*\[env:([^]]+)]\s*", raw_line)
+        if match:
+            environments.add(match.group(1).strip())
+    return environments
+
+
+def infer_channel(environment: str, explicit: str | None) -> str:
+    upper = environment.upper()
+    inferred = "release" if "RELEASE" in upper else "debug" if "DEBUG" in upper else None
+    if inferred:
+        if explicit and explicit != inferred:
+            raise ValueError(
+                f"environment {environment!r} implies {inferred!r}, not {explicit!r}"
+            )
+        return inferred
+    if explicit:
+        return explicit
+    raise ValueError(
+        f"cannot infer channel from environment {environment!r}; use --channel"
+    )
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def locate_binary(
+    environment: str,
+    version: str,
+    explicit: Path | None,
+    *,
+    project_root: Path = ROOT,
+) -> Path:
+    if explicit is not None:
+        binary = explicit.expanduser().resolve()
+        if not binary.is_file() or binary.suffix.lower() != ".bin":
+            raise FileNotFoundError(f"firmware binary not found: {binary}")
+        if binary.name.startswith("Firmware_") and not binary.name.startswith(
+            f"Firmware_{environment}_"
+        ):
+            raise ValueError(
+                f"binary name does not match environment {environment!r}: {binary.name}"
+            )
+        if binary.parent.parent.name == "build" and binary.parent.name != environment:
+            raise ValueError(
+                f"binary build directory does not match environment {environment!r}: "
+                f"{binary.parent.name!r}"
+            )
+        return binary
+
+    build_dir = project_root / ".pio" / "build" / environment
+    matches = sorted(build_dir.glob(f"Firmware_{environment}_{version} - *.bin"))
+    if len(matches) > 1:
+        names = ", ".join(path.name for path in matches)
+        raise ValueError(f"multiple matching binaries found; use --bin: {names}")
+    if len(matches) == 1:
+        return matches[0].resolve()
+
+    fallback = build_dir / "firmware.bin"
+    if fallback.is_file():
+        return fallback.resolve()
+    raise FileNotFoundError(
+        f"no binary for {environment} {version} in {build_dir}; build it first"
+    )
+
+
+def resolve_build_date(binary: Path, explicit: str | None) -> date:
+    if explicit:
+        return parse_iso_date(explicit, label="build date")
+    match = GENERATED_NAME_PATTERN.search(binary.name)
+    if match:
+        return datetime.strptime(match.group(1), "%d.%m.%Y").date()
+    return date.today()
+
+
+def git_state(project_root: Path = ROOT) -> tuple[str, str]:
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=project_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        dirty = subprocess.run(
+            ["git", "status", "--porcelain", "--untracked-files=no"],
+            cwd=project_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        return commit, "yes" if dirty else "no"
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown", "unknown"
+
+
+def validate_owned_destination(destination: Path) -> None:
+    if not destination.exists():
+        return
+    if destination.is_symlink() or not destination.is_dir():
+        raise ValueError(f"output path is not a regular directory: {destination}")
+    entries = [entry for entry in destination.iterdir() if entry.name != ".DS_Store"]
+    marker = destination / EXPORT_MARKER
+    if entries and (not marker.is_file() or marker.is_symlink()):
+        raise ValueError(f"refusing to replace unowned directory: {destination}")
+
+
+def read_build_info(directory: Path) -> dict[str, str]:
+    path = directory / "BUILD_INFO.txt"
+    if not path.is_file():
+        raise ValueError(f"missing build information: {path}")
+    values: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if ": " in line:
+            key, value = line.split(": ", 1)
+            values[key] = value
+    required = ("Version", "Environment", "Channel", "Build date", "Binary")
+    for key in required:
+        if not values.get(key):
+            raise ValueError(f"missing {key!r} in {path}")
+    if not VERSION_PATTERN.fullmatch(values["Version"]):
+        raise ValueError(f"invalid version in {path}")
+    if values["Channel"] not in ("debug", "release"):
+        raise ValueError(f"invalid channel in {path}")
+    parse_iso_date(values["Build date"], label="build date")
+    if Path(values["Binary"]).name != values["Binary"]:
+        raise ValueError(f"invalid binary name in {path}")
+    return values
+
+
+def verified_checksum(directory: Path) -> tuple[str, str]:
+    manifest = directory / "SHA256SUMS.txt"
+    if not manifest.is_file():
+        raise ValueError(f"missing checksum manifest: {manifest}")
+    lines = manifest.read_text(encoding="ascii").splitlines()
+    if len(lines) != 1:
+        raise ValueError(f"expected exactly one checksum in {manifest}")
+    match = CHECKSUM_PATTERN.fullmatch(lines[0])
+    if match is None:
+        raise ValueError(f"malformed checksum in {manifest}")
+    expected, name = match.groups()
+    binary = directory / name
+    if not binary.is_file() or binary.suffix.lower() != ".bin":
+        raise ValueError(f"missing checksummed binary: {binary}")
+    if sha256(binary) != expected:
+        raise ValueError(f"checksum mismatch for {binary}")
+    return name, expected
+
+
+def verify_export(
+    directory: Path,
+    *,
+    expected_channel: str | None = None,
+    expected_env: str | None = None,
+) -> tuple[dict[str, str], str]:
+    export_dir = directory.expanduser().resolve()
+    if (
+        not export_dir.is_dir()
+        or export_dir.is_symlink()
+        or not (export_dir / EXPORT_MARKER).is_file()
+        or (export_dir / EXPORT_MARKER).is_symlink()
+    ):
+        raise ValueError(f"not an EasyIot firmware export: {export_dir}")
+    info = read_build_info(export_dir)
+    name, digest = verified_checksum(export_dir)
+    if info["Binary"] != name:
+        raise ValueError("BUILD_INFO.txt and SHA256SUMS.txt name different binaries")
+    expected_name = (
+        f"ONOFRE_{filename_token(info['Environment'])}_"
+        f"{filename_token(info['Version'])}_{info['Build date']}.bin"
+    )
+    if name != expected_name:
+        raise ValueError(f"binary name does not match its build metadata: {name}")
+    if expected_channel and info["Channel"] != expected_channel:
+        raise ValueError(
+            f"expected channel {expected_channel!r}, found {info['Channel']!r}"
+        )
+    if expected_env and info["Environment"] != expected_env:
+        raise ValueError(
+            f"expected environment {expected_env!r}, found {info['Environment']!r}"
+        )
+    return info, digest
+
+
+def export_identity(info: dict[str, str]) -> tuple[str, ...]:
+    """Return fields that identify the built artifact, excluding promotion metadata."""
+    return tuple(
+        info.get(key, "")
+        for key in (
+            "Version",
+            "Environment",
+            "Channel",
+            "Build date",
+            "Git commit",
+            "Tracked changes present",
+            "Binary",
+        )
+    )
+
+
+def write_export(
+    staging: Path,
+    *,
+    binary: Path,
+    output_name: str,
+    version: str,
+    environment: str,
+    channel: str,
+    build_date: date,
+    commit: str,
+    dirty: str,
+) -> None:
+    output = staging / output_name
+    shutil.copy2(binary, output)
+    digest = sha256(output)
+    (staging / "SHA256SUMS.txt").write_text(
+        f"{digest}  {output.name}\n", encoding="ascii"
+    )
+    (staging / "BUILD_INFO.txt").write_text(
+        "\n".join(
+            (
+                "EASYIOT FIRMWARE CANDIDATE",
+                "",
+                f"Version: {version}",
+                f"Environment: {environment}",
+                f"Channel: {channel}",
+                f"Build date: {build_date.isoformat()}",
+                f"Git commit: {commit}",
+                f"Tracked changes present: {dirty}",
+                f"Binary: {output.name}",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    (staging / EXPORT_MARKER).write_text(
+        "Owned by tools/export_firmware.py\n", encoding="ascii"
+    )
+
+
+def publish(
+    *,
+    environment: str,
+    channel: str | None,
+    explicit_binary: Path | None,
+    output_root: Path,
+    date_stamp: str | None,
+    project_root: Path = ROOT,
+) -> Path:
+    platformio_ini = project_root / "platformio.ini"
+    version = read_project_version(platformio_ini)
+    environments = read_project_environments(platformio_ini)
+    if environment not in environments:
+        raise ValueError(f"unknown PlatformIO environment: {environment}")
+    resolved_channel = infer_channel(environment, channel)
+    binary = locate_binary(
+        environment, version, explicit_binary, project_root=project_root
+    )
+    build_date = resolve_build_date(binary, date_stamp)
+    destination = (
+        output_root.expanduser().resolve()
+        / "candidate"
+        / resolved_channel
+        / filename_token(environment)
+    )
+    validate_owned_destination(destination)
+
+    output_name = (
+        f"ONOFRE_{filename_token(environment)}_{filename_token(version)}_"
+        f"{build_date.isoformat()}.bin"
+    )
+    if destination.is_dir() and (destination / EXPORT_MARKER).is_file():
+        try:
+            info, existing_digest = verify_export(destination)
+            if (
+                info["Version"] == version
+                and info["Environment"] == environment
+                and info["Channel"] == resolved_channel
+                and info["Build date"] == build_date.isoformat()
+                and existing_digest == sha256(binary)
+            ):
+                print(f"Firmware candidate is already current: {destination}")
+                return destination
+        except (OSError, UnicodeError, ValueError):
+            pass
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{destination.name}.new-", dir=destination.parent)
+    )
+    backup = destination.parent / f".{destination.name}.old-{uuid.uuid4().hex}"
+    try:
+        commit, dirty = git_state(project_root)
+        write_export(
+            staging,
+            binary=binary,
+            output_name=output_name,
+            version=version,
+            environment=environment,
+            channel=resolved_channel,
+            build_date=build_date,
+            commit=commit,
+            dirty=dirty,
+        )
+        if destination.exists():
+            os.replace(destination, backup)
+        try:
+            os.replace(staging, destination)
+        except Exception:
+            if backup.exists() and not destination.exists():
+                os.replace(backup, destination)
+            raise
+        if backup.exists():
+            shutil.rmtree(backup)
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging)
+    verify_export(
+        destination,
+        expected_channel=resolved_channel,
+        expected_env=environment,
+    )
+    print(f"Firmware candidate published: {destination}")
+    return destination
+
+
+def promote(
+    *,
+    candidate_dir: Path,
+    known_good_root: Path,
+    hardware_tested_date: str,
+) -> Path:
+    candidate = candidate_dir.expanduser().resolve()
+    tested = (
+        date.today()
+        if hardware_tested_date == "today"
+        else parse_iso_date(hardware_tested_date, label="hardware-tested date")
+    )
+    if tested > date.today():
+        raise ValueError("hardware-tested date must not be in the future")
+
+    info, digest = verify_export(candidate)
+    build_date = parse_iso_date(info["Build date"], label="build date")
+    if tested < build_date:
+        raise ValueError("hardware-tested date must not precede the build date")
+    version_dir = filename_token(info["Version"])
+    if not version_dir.lower().startswith("v"):
+        version_dir = f"v{version_dir}"
+    destination = (
+        known_good_root.expanduser().resolve()
+        / filename_token(info["Environment"])
+        / version_dir
+    )
+    if destination.exists():
+        existing_info, existing_digest = verify_export(destination)
+        if export_identity(existing_info) == export_identity(info) and existing_digest == digest:
+            print(f"Known-good firmware already exists: {destination}")
+            return destination
+        raise ValueError(
+            "known-good version already exists with different firmware or metadata; "
+            "use a new version instead of overwriting it"
+        )
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{version_dir}.new-", dir=destination.parent)
+    )
+    try:
+        for name in (info["Binary"], "SHA256SUMS.txt"):
+            shutil.copy2(candidate / name, staging / name)
+        (staging / "BUILD_INFO.txt").write_text(
+            (candidate / "BUILD_INFO.txt").read_text(encoding="utf-8")
+            + f"Hardware-tested: {tested.isoformat()}\n"
+            + f"Promoted: {date.today().isoformat()}\n"
+            + "Status: hardware-tested known-good\n",
+            encoding="utf-8",
+        )
+        (staging / "RESTORE.txt").write_text(
+            "\n".join(
+                (
+                    "EASYIOT KNOWN-GOOD LOCAL FIRMWARE",
+                    "",
+                    f"Environment: {info['Environment']}",
+                    f"Version: {info['Version']}",
+                    f"Hardware-tested: {tested.isoformat()}",
+                    f"Binary: {info['Binary']}",
+                    "",
+                    "Verify the board variant before flashing this application binary.",
+                    "This ignored local directory is not an off-machine backup.",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        (staging / EXPORT_MARKER).write_text(
+            "Owned by tools/export_firmware.py\n", encoding="ascii"
+        )
+        if destination.exists():
+            raise ValueError(f"known-good destination appeared: {destination}")
+        os.replace(staging, destination)
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging)
+    verify_export(destination)
+    print(f"Known-good firmware promoted: {destination}")
+    return destination
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "publish":
+            publish(
+                environment=args.env,
+                channel=args.channel,
+                explicit_binary=args.bin,
+                output_root=args.output_root,
+                date_stamp=args.date_stamp,
+            )
+        elif args.command == "verify":
+            info, digest = verify_export(
+                args.export_dir,
+                expected_channel=args.expected_channel,
+                expected_env=args.expected_env,
+            )
+            print("EasyIot firmware export verified:")
+            print(f"  Environment: {info['Environment']}")
+            print(f"  Version: {info['Version']}")
+            print(f"  Channel: {info['Channel']}")
+            print(f"  Binary: {args.export_dir.expanduser().resolve() / info['Binary']}")
+            print(f"  SHA-256: {digest}")
+        else:
+            promote(
+                candidate_dir=args.candidate_dir,
+                known_good_root=args.known_good_root,
+                hardware_tested_date=args.hardware_tested_date,
+            )
+    except (FileNotFoundError, OSError, UnicodeError, ValueError) as error:
+        raise SystemExit(f"Firmware export failed: {error}") from error
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/post_extra_script.py
+++ b/tools/post_extra_script.py
@@ -1,0 +1,50 @@
+"""PlatformIO post-build hook for local firmware candidate exports."""
+
+import os
+import subprocess
+import sys
+
+from SCons.Script import Action, DefaultEnvironment  # type: ignore
+
+
+env = DefaultEnvironment()
+
+
+def export_firmware_candidate(target, source, env):
+    pioenv = env.get("PIOENV", "")
+    project_dir = env["PROJECT_DIR"]
+    script_path = os.path.join(project_dir, "tools", "export_firmware.py")
+    binary_path = env.subst("$BUILD_DIR/${PROGNAME}.bin")
+    if not os.path.isfile(script_path):
+        print("Firmware export failed: export_firmware.py not found.")
+        return 1
+    if not os.path.isfile(binary_path):
+        print(f"Firmware export failed: binary not found: {binary_path}")
+        return 1
+
+    print("")
+    print("Publishing local firmware candidate ...")
+    subprocess.run(
+        [
+            sys.executable,
+            script_path,
+            "publish",
+            "--env",
+            pioenv,
+            "--bin",
+            binary_path,
+        ],
+        check=True,
+    )
+    print("")
+    return 0
+
+
+pioenv = env.get("PIOENV", "")
+if "DEBUG" in pioenv or "RELEASE" in pioenv:
+    firmware_binary = env.File(env.subst("$BUILD_DIR/${PROGNAME}.bin"))
+    env.AlwaysBuild(firmware_binary)
+    env.AddPostAction(
+        firmware_binary,
+        Action(export_firmware_candidate, "Post-build: local firmware candidate"),
+    )

--- a/tools/test_export_firmware.py
+++ b/tools/test_export_firmware.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Host-only tests for the local EasyIot firmware export workflow."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("export_firmware.py")
+SPEC = importlib.util.spec_from_file_location("export_firmware", SCRIPT)
+assert SPEC and SPEC.loader
+export_firmware = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(export_firmware)
+
+
+class FirmwareExportTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        (self.root / "platformio.ini").write_text(
+            "[extra]\nversion = 9.177-dev\n\n"
+            "[env:ESP8266_DEBUG]\n\n"
+            "[env:ESP8266_RELEASE]\n\n"
+            "[env:ESP32_DEBUG]\n\n"
+            "[env:ESP32_TEST]\n",
+            encoding="utf-8",
+        )
+        self.binary = self.root / "input.bin"
+        self.binary.write_bytes(b"easyiot-firmware-one")
+        self.output = self.root / "firmware_bins"
+
+    def tearDown(self) -> None:
+        self.temp.cleanup()
+
+    def publish(self, **overrides: object) -> Path:
+        values: dict[str, object] = {
+            "environment": "ESP8266_DEBUG",
+            "channel": None,
+            "explicit_binary": self.binary,
+            "output_root": self.output,
+            "date_stamp": "2026-08-18",
+            "project_root": self.root,
+        }
+        values.update(overrides)
+        return export_firmware.publish(**values)
+
+    def test_publish_creates_verified_environment_specific_candidate(self) -> None:
+        candidate = self.publish()
+        info, digest = export_firmware.verify_export(
+            candidate, expected_channel="debug", expected_env="ESP8266_DEBUG"
+        )
+        self.assertEqual(info["Version"], "9.177-dev")
+        self.assertEqual(digest, export_firmware.sha256(self.binary))
+        self.assertEqual(len(list(candidate.glob("*.bin"))), 1)
+
+    def test_identical_publish_is_idempotent(self) -> None:
+        candidate = self.publish()
+        before = (candidate / "BUILD_INFO.txt").read_bytes()
+        repeated = self.publish()
+        self.assertEqual(candidate, repeated)
+        self.assertEqual((candidate / "BUILD_INFO.txt").read_bytes(), before)
+
+    def test_release_environment_uses_a_separate_release_candidate(self) -> None:
+        candidate = self.publish(environment="ESP8266_RELEASE")
+        info, _ = export_firmware.verify_export(
+            candidate,
+            expected_channel="release",
+            expected_env="ESP8266_RELEASE",
+        )
+        self.assertEqual(
+            candidate.resolve(),
+            (self.output / "candidate" / "release" / "ESP8266_RELEASE").resolve(),
+        )
+        self.assertEqual(info["Channel"], "release")
+
+    def test_publish_replaces_only_an_owned_candidate(self) -> None:
+        candidate = self.publish()
+        self.binary.write_bytes(b"easyiot-firmware-two")
+        self.publish()
+        _, digest = export_firmware.verify_export(candidate)
+        self.assertEqual(digest, export_firmware.sha256(self.binary))
+
+        unowned = self.output / "candidate" / "debug" / "ESP32_DEBUG"
+        unowned.mkdir(parents=True)
+        (unowned / "keep.txt").write_text("user data\n", encoding="utf-8")
+        with self.assertRaisesRegex(ValueError, "unowned"):
+            self.publish(environment="ESP32_DEBUG")
+        self.assertTrue((unowned / "keep.txt").is_file())
+
+    def test_tampered_binary_fails_verification(self) -> None:
+        candidate = self.publish()
+        next(candidate.glob("*.bin")).write_bytes(b"tampered")
+        with self.assertRaisesRegex(ValueError, "checksum mismatch"):
+            export_firmware.verify_export(candidate)
+
+    def test_ambiguous_automatic_binary_selection_fails_closed(self) -> None:
+        build = self.root / ".pio" / "build" / "ESP8266_DEBUG"
+        build.mkdir(parents=True)
+        for stamp in ("17.08.2026", "18.08.2026"):
+            (build / f"Firmware_ESP8266_DEBUG_9.177-dev - {stamp}.bin").write_bytes(
+                stamp.encode("ascii")
+            )
+        with self.assertRaisesRegex(ValueError, "multiple matching binaries"):
+            export_firmware.locate_binary(
+                "ESP8266_DEBUG", "9.177-dev", None, project_root=self.root
+            )
+
+    def test_promote_preserves_candidate_and_refuses_changed_identity(self) -> None:
+        candidate = self.publish()
+        known_good_root = self.output / "known-good"
+        promoted = export_firmware.promote(
+            candidate_dir=candidate,
+            known_good_root=known_good_root,
+            hardware_tested_date="2026-08-18",
+        )
+        self.assertTrue(candidate.is_dir())
+        self.assertTrue((promoted / "RESTORE.txt").is_file())
+        repeated = export_firmware.promote(
+            candidate_dir=candidate,
+            known_good_root=known_good_root,
+            hardware_tested_date="2026-08-18",
+        )
+        self.assertEqual(promoted, repeated)
+
+        self.binary.write_bytes(b"different-bytes-same-version")
+        changed_candidate = self.publish()
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            export_firmware.promote(
+                candidate_dir=changed_candidate,
+                known_good_root=known_good_root,
+                hardware_tested_date="2026-08-18",
+            )
+
+    def test_promote_rejects_invalid_test_dates(self) -> None:
+        candidate = self.publish()
+        with self.assertRaisesRegex(ValueError, "precede"):
+            export_firmware.promote(
+                candidate_dir=candidate,
+                known_good_root=self.output / "known-good",
+                hardware_tested_date="2026-08-17",
+            )
+        with self.assertRaisesRegex(ValueError, "future"):
+            export_firmware.promote(
+                candidate_dir=candidate,
+                known_good_root=self.output / "known-good",
+                hardware_tested_date=(date.today() + timedelta(days=1)).isoformat(),
+            )
+
+    def test_nonstandard_environment_requires_explicit_channel(self) -> None:
+        with self.assertRaisesRegex(ValueError, "use --channel"):
+            export_firmware.infer_channel("ESP32_TEST", None)
+        self.assertEqual(
+            export_firmware.infer_channel("ESP32_TEST", "debug"), "debug"
+        )
+
+    def test_publish_rejects_unknown_environment_and_channel_contradiction(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unknown PlatformIO environment"):
+            self.publish(environment="ESP8266_TYP0")
+        with self.assertRaisesRegex(ValueError, "implies 'debug'"):
+            self.publish(channel="release")
+
+    def test_explicit_generated_binary_must_match_environment(self) -> None:
+        wrong = self.root / "Firmware_ESP32_DEBUG_9.177-dev - 18.08.2026.bin"
+        wrong.write_bytes(b"esp32")
+        with self.assertRaisesRegex(ValueError, "does not match environment"):
+            export_firmware.locate_binary(
+                "ESP8266_DEBUG", "9.177-dev", wrong, project_root=self.root
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Add a safe local workflow for preserving PlatformIO firmware binaries as environment-specific candidates and promoting hardware-tested candidates to immutable known-good copies.

## Changes

- Add tools/export_firmware.py with publish, verify, and promote commands.
- Automatically export successful DEBUG and RELEASE builds through a PlatformIO post-build hook.
- Store candidates separately by channel and environment under firmware_bins/.

```text
firmware_bins/
├── candidate/
│   ├── debug/
│   └── release/
└── known-good/
```

- Include BUILD_INFO.txt and SHA256SUMS.txt with every candidate.
- Preserve hardware-tested builds under known-good/<environment>/v<version>/.
- Refuse ambiguous binaries, environment mismatches, checksum failures, unowned destination replacement, and known-good overwrites.
- Ignore the generated firmware_bins/ directory so binaries remain local.
- Document the workflow in README.md and docs/RELEASE_WORKFLOW.md.
- Add host-only regression tests for publication, verification, promotion, channel separation, idempotency, and failure cases.

## Why

PlatformIO build output under .pio is disposable. Keeping a verified candidate makes it easy to recover the exact binary that was built, while the explicit promotion step prevents an untested build from being labelled known-good. Environment-specific folders also reduce the risk of flashing an ESP8266, HAN, or ESP32 binary onto the wrong board.

## Validation

- python3 -m unittest -v tools/test_export_firmware.py — 11 tests passed.
- platformio run -e ESP8266_DEBUG — passed; RAM 45,616 / 81,920 bytes (55.7%), flash 699,397 / 1,044,464 bytes (67.0%).
- platformio run -e ESP32_DEBUG — passed; RAM 65,964 / 327,680 bytes (20.1%), flash 1,353,493 / 3,342,336 bytes (40.5%).
- Confirmed both builds automatically created and verified their environment-specific candidates.
- Confirmed an unchanged cached ESP8266 build performs an idempotent export.
- Revalidated on development v9.177-dev: ESP8266 build passed and the exported SHA-256 manifest verified.
- git diff --check passed.

## Notes

- This PR changes build tooling only; it does not change firmware runtime behavior.
- Generated binaries and local Wi-Fi credentials are not included in the PR.
- Known-good promotion remains a deliberate manual action after hardware testing.
- firmware_bins/ is local storage, not an off-machine backup.