### PR TITLE
docs(release): add firmware rollback playbook

### DIFF
--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -37,7 +37,6 @@
 
 1. [x] CI build checks for main envs — `.github/workflows/firmware-ota.yml` builds all four release envs (ESP8266, ESP8266-HAN, ESP32, ESP32-MAKER-4MB) and publishes them to the OTA folder on tag/dispatch.
 2. [ ] Add smoke tests for boot, Wi-Fi, MQTT, OTA update path.
-3. [ ] Add quick rollback notes for failed release/update.
 
 #
 
@@ -87,6 +86,7 @@
 2. [x] Added branch naming convention for external CP branches. File: `docs/RELEASE_WORKFLOW.md`
 3. [x] Added release checklist document in repo docs. File: `docs/RELEASE_WORKFLOW.md`
 4. [x] Added script to generate release notes draft from commits. File: `tools/generate_release_notes.sh`
+5. [x] Added an exact-variant rollback playbook for WebUI OTA recovery, full-flash recovery, configuration restore, containment, and post-rollback verification. File: `docs/RELEASE_WORKFLOW.md`
 
 ## Security & API
 

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -113,6 +113,66 @@ tool refuses to overwrite it with different bytes or metadata. Every export has
 `BUILD_INFO.txt` and `SHA256SUMS.txt`. The ignored local directory is not an
 off-machine backup; archive important known-good firmware separately.
 
+## Quick Rollback
+
+A rollback installs a previously hardware-tested build for the exact device
+variant. Do not choose a binary from the MCU family alone: standard, HAN, and
+other board profiles can use different firmware and partition layouts.
+
+### Prepare Before Deployment
+
+1. In the WebUI, open **System -> Access & Backup** and export the device
+   configuration.
+2. Verify the candidate that passed hardware testing:
+   - `python3 tools/export_firmware.py verify --export-dir firmware_bins/candidate/debug/ESP8266_DEBUG --expected-env ESP8266_DEBUG`
+3. Promote that exact candidate to the immutable local known-good area:
+   - `python3 tools/export_firmware.py promote --candidate-dir firmware_bins/candidate/debug/ESP8266_DEBUG --hardware-tested-date today`
+4. Archive the known-good binary, `BUILD_INFO.txt`, and `SHA256SUMS.txt` outside
+   the ignored local `firmware_bins/` directory.
+
+### Device WebUI Is Reachable
+
+1. Identify the current board/variant and select the matching previous
+   application binary. A local known-good export can be checked again with:
+   - `python3 tools/export_firmware.py verify --export-dir firmware_bins/known-good/<ENV>/v<VERSION> --expected-env <ENV>`
+2. Open **System -> Firmware**, choose that `.bin`, and send it to the device.
+3. Keep the device powered until the upload completes and it restarts.
+4. Reopen the WebUI and verify the displayed firmware version, Wi-Fi, CloudIO or
+   MQTT connection, and basic actuator/sensor operation.
+
+This application-only OTA path normally preserves the stored configuration. Do
+not factory-reset the device as part of a routine rollback.
+
+### Device WebUI Is Unreachable or It Boot-Loops
+
+1. Use the matching full-flash `ONOFRE_<MCU>_WEBFLASH_<VERSION>.bin` artifact
+   through the browser installer at `/flash/`, or use the same artifact from the
+   CI run that built the release.
+2. Prefer a published, hardware-tested full-flash image. Do not use an
+   application-only `ONOFRE_<MCU>_RELEASE_<VERSION>.bin` as a blank-chip image
+   for ESP32-family devices; it does not include the bootloader and partition
+   data.
+3. Expect full-flash recovery to be capable of erasing configuration. Once the
+   device is reachable, restore the configuration export made before deployment.
+4. If rebuilding from source is unavoidable, check out the exact known-good
+   commit/tag, select the exact PlatformIO environment, build it, and record the
+   binary and checksum used.
+
+Do not copy raw flash offsets between ESP8266, ESP32, and ESP32-C6 recovery
+commands. Their complete images and layouts differ. If the device cannot enter
+its serial bootloader, physical access to its boot/reset controls and a working
+USB data connection is required; WebUI recovery is no longer possible.
+
+### Contain and Verify the Rollback
+
+1. The release owner should stop offering the faulty artifact before rolling
+   devices back, so an automatic update cannot immediately reinstall it.
+2. Record the affected variant, failed version, observed failure, rollback
+   version, binary checksum, and configuration-restoration result.
+3. Treat the rollback as complete only after restart, reconnect, control, and
+   relevant sensor checks pass on the real device.
+4. Correct and revalidate the release before publishing it again.
+
 ## Practical Notes
 
 - Prefer one CP per logical scope (security, webpanel, docs, etc.).


### PR DESCRIPTION
## Summary

Add a practical, exact-variant rollback playbook for failed firmware releases and OTA updates, covering both WebUI recovery and USB/full-flash recovery.

## Changes

- Document preparation before deployment:
  - export the device configuration
  - verify the hardware-tested candidate
  - promote it to immutable local known-good storage
  - archive its binary, build metadata, and checksum off-machine
- Document rollback while the device WebUI remains reachable:
  - select the previous application binary for the exact environment
  - verify and upload it through **System -> Firmware**
  - confirm version, connectivity, controls, and sensors after restart
- Document recovery when the WebUI is unreachable or the device boot-loops:
  - use the matching full-flash `WEBFLASH` image
  - distinguish full-flash images from application-only OTA binaries
  - restore configuration after recovery when required
- Warn against copying raw flash offsets between ESP8266, ESP32, and ESP32-C6.
- Add containment and post-rollback verification steps.
- Move the rollback task from the TODO backlog to Done.

## Why

A failed update needs a repeatable recovery path. Guessing a binary from the MCU family, confusing an OTA application image with a full-flash image, or re-offering the faulty release can leave a device unrecoverable without physical access.

The guide makes the safe path explicit before an incident occurs and ties it to the existing configuration export, local known-good firmware, CI artifacts, and browser installer.

## Validation

- `python3 -B tools/check_project.py --quick`
  - 16 host tests passed
  - Python and JavaScript syntax passed
  - generated WebUI asset parity passed
  - conflict-marker and whitespace checks passed
  - release metadata passed with only the two expected warnings for test environments that intentionally disable `WEB_SECURE_ON`
- `git diff --check upstream/master...HEAD`
- Verified the documented behavior against:
  - `tools/export_firmware.py` verify/promote behavior
  - the WebUI configuration export/restore and manual firmware upload paths
  - CI generation of separate OTA and `WEBFLASH` artifacts

## Notes

- Documentation only; no firmware or WebUI runtime behavior changes.
- No firmware build was required for this scope.
- The instructions deliberately avoid generic raw flashing commands because flash layouts differ by target.
