### PR TITLE
chore(deps): add environment audit runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this project are documented in this file.
   the main loop, saved, and followed by a controlled restart instead of reporting
   success while leaving the old template active. ESP32 feature readers are
   quiesced before their vectors are replaced.
+### Changed
+- Added a non-updating dependency audit runner that reports outdated PlatformIO
+  packages per configured environment, continues after target-specific failures,
+  and documents why available updates still require build and hardware validation.
 
 ## [9.181] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ Para incluir uma compilação da configuração atual:
 Consulte [docs/RELEASE_WORKFLOW.md](docs/RELEASE_WORKFLOW.md#project-checks)
 para a matriz completa e os detalhes de cada verificação.
 
+Para consultar atualizações disponíveis sem alterar `platformio.ini` nem
+atualizar dependências automaticamente:
+
+- `python3 tools/audit_dependencies.py`
+- apenas um ambiente: `python3 tools/audit_dependencies.py --env ESP8266_DEBUG`
+
 ## Binários locais de firmware
 
 Depois de compilar com PlatformIO, `tools/export_firmware.py` pode guardar o

--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -26,7 +26,6 @@
 
 1. [ ] Pin PlatformIO platforms to known-good versions (`espressif32@...`, `espressif8266@...`) for reproducible builds. File: `platformio.ini`
 2. [x] Pin GitHub-based `lib_deps` to tags/registry versions (avoid floating `master/main`) — SHT4x pinned to 1.1.2 after upstream renamed a header and broke every Linux build; the remaining git URLs are still unpinned. File: `platformio.ini`
-3. [ ] Add periodic dependency audit task (`pio pkg outdated` + compatibility notes per env).
 
 ## Webpanel UX (P1/P2)
 
@@ -80,6 +79,7 @@
 
 1. [x] Replaced deprecated ArduinoJson `containsKey()` checks in config update path with `isNull()` guards. File: `src/ConfigOnofre.cpp`
 2. [x] Added explicit ESP8266 no-op switch cases for ESP32-only sensor drivers (`TMF882X`, `LD2410`) to remove compiler switch warnings. File: `src/Sensors.cpp`
+3. [x] Added a non-updating PlatformIO dependency audit that checks each configured environment independently and explains `Current`, `Wanted`, `Latest`, and Git dependency limitations. Files: `tools/audit_dependencies.py`, `tools/test_audit_dependencies.py`
 
 ## Process & Release
 

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -68,6 +68,32 @@ metadata, generated web-header parity, conflict markers, and whitespace. Web
 asset parity is checked in a temporary directory, so the command does not
 rewrite working-tree headers.
 
+## Dependency Audit
+
+Run the periodic dependency audit across every configured PlatformIO
+environment:
+
+- `python3 tools/audit_dependencies.py`
+
+Audit only selected environments when investigating a specific target:
+
+- `python3 tools/audit_dependencies.py --env ESP8266_DEBUG`
+- `python3 tools/audit_dependencies.py --env ESP8266_DEBUG --env ESP32_DEBUG`
+
+The runner executes `pio pkg outdated` independently for each environment, so a
+broken platform does not hide the results for other targets. It reports
+`Current`, `Wanted`, and `Latest` versions but never edits `platformio.ini` or
+updates declared packages. PlatformIO may still refresh its own registry cache
+or prepare an environment while inspecting it. The runner exits nonzero if any
+environment could not be audited, while still printing results for the remaining
+environments.
+
+Treat the output as an investigation list, not an upgrade recommendation.
+`Wanted` follows the current declaration; `Latest` may be incompatible, and Git
+dependencies may point at a moving branch. Upgrade one dependency family at a
+time, then run the relevant build matrix and hardware checks before changing a
+pin.
+
 ## Local Wi-Fi Override
 
 1. Copy `platformio_override.example.ini` to `platformio_override.ini`.

--- a/tools/audit_dependencies.py
+++ b/tools/audit_dependencies.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Report outdated PlatformIO packages without changing project declarations."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLATFORMIO_INI = ROOT / "platformio.ini"
+
+
+def configured_environments(platformio_ini: Path = PLATFORMIO_INI) -> list[str]:
+    environments: list[str] = []
+    for raw_line in platformio_ini.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line.startswith("[env:") and line.endswith("]"):
+            environments.append(line[5:-1].strip())
+    if not environments:
+        raise RuntimeError(f"no PlatformIO environments found in {platformio_ini}")
+    return environments
+
+
+def platformio_command() -> str:
+    for name in ("platformio", "pio"):
+        command = shutil.which(name)
+        if command:
+            return command
+    raise RuntimeError("PlatformIO is not installed or not on PATH")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="ENV",
+        help="audit one environment; may be repeated (default: every configured environment)",
+    )
+    return parser.parse_args()
+
+
+def selected_environments(requested: list[str], configured: list[str]) -> list[str]:
+    if not requested:
+        return configured
+    unknown = [environment for environment in requested if environment not in configured]
+    if unknown:
+        raise RuntimeError("unknown PlatformIO environment(s): " + ", ".join(unknown))
+    return list(dict.fromkeys(requested))
+
+
+def audit_environment(command: str, environment: str) -> tuple[bool, str]:
+    try:
+        result = subprocess.run(
+            [command, "pkg", "outdated", "-e", environment],
+            cwd=ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    except OSError as error:
+        return False, f"could not run PlatformIO: {error}"
+    return result.returncode == 0, (result.stdout or "").strip()
+
+
+def print_notes() -> None:
+    print("Compatibility notes:")
+    print("- Current is the locally resolved package version.")
+    print("- Wanted is the newest version allowed by the current declaration.")
+    print("- Latest may contain breaking changes and is not an upgrade recommendation.")
+    print("- Git dependencies may compare against a moving branch rather than a release.")
+    print("- An audit does not prove compatibility; build and test every affected target.")
+    print("- This tool does not edit platformio.ini or update declared dependencies.")
+
+
+def main() -> int:
+    try:
+        configured = configured_environments()
+        environments = selected_environments(parse_args().env, configured)
+        command = platformio_command()
+    except (OSError, RuntimeError) as error:
+        print(f"Dependency audit failed: {error}", file=sys.stderr)
+        return 2
+
+    print_notes()
+    print(f"\nAuditing {len(environments)} environment(s) with: {command}")
+
+    failed: list[str] = []
+    for environment in environments:
+        print(f"\n--- {environment} ---", flush=True)
+        passed, output = audit_environment(command, environment)
+        if output:
+            print(output)
+        if passed:
+            print(f"[PASS] {environment}")
+        else:
+            print(f"[FAIL] {environment}")
+            failed.append(environment)
+
+    print("\n==============================================")
+    print(
+        f"Dependency audit: {len(environments) - len(failed)} passed, "
+        f"{len(failed)} failed"
+    )
+    print("==============================================")
+    if failed:
+        print("Could not audit: " + ", ".join(failed))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_audit_dependencies.py
+++ b/tools/test_audit_dependencies.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Host-only tests for the PlatformIO dependency audit runner."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("audit_dependencies.py")
+SPEC = importlib.util.spec_from_file_location("audit_dependencies", SCRIPT)
+assert SPEC and SPEC.loader
+audit_dependencies = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(audit_dependencies)
+
+
+class DependencyAuditTests(unittest.TestCase):
+    def test_environment_parser_preserves_platformio_order(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            ini = Path(temporary) / "platformio.ini"
+            ini.write_text(
+                "[base]\nboard = esp12e\n\n"
+                "[env:ESP8266_DEBUG]\nextends = base\n\n"
+                " [env:ESP32_DEBUG] \nextends = base\n",
+                encoding="utf-8",
+            )
+            self.assertEqual(
+                audit_dependencies.configured_environments(ini),
+                ["ESP8266_DEBUG", "ESP32_DEBUG"],
+            )
+
+    def test_all_environments_are_selected_by_default(self) -> None:
+        configured = ["ESP8266_DEBUG", "ESP32_DEBUG"]
+        self.assertEqual(
+            audit_dependencies.selected_environments([], configured), configured
+        )
+
+    def test_requested_environments_are_deduplicated(self) -> None:
+        self.assertEqual(
+            audit_dependencies.selected_environments(
+                ["ESP32_DEBUG", "ESP32_DEBUG"],
+                ["ESP8266_DEBUG", "ESP32_DEBUG"],
+            ),
+            ["ESP32_DEBUG"],
+        )
+
+    def test_unknown_environment_is_rejected(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "unknown PlatformIO environment"):
+            audit_dependencies.selected_environments(
+                ["NOT_REAL"], ["ESP8266_DEBUG"]
+            )
+
+    @mock.patch.object(audit_dependencies.subprocess, "run")
+    def test_audit_uses_outdated_command(self, run: mock.Mock) -> None:
+        run.return_value = mock.Mock(returncode=0, stdout="Packages are up-to-date")
+        passed, output = audit_dependencies.audit_environment(
+            "/usr/bin/pio", "ESP8266_DEBUG"
+        )
+        self.assertTrue(passed)
+        self.assertEqual(output, "Packages are up-to-date")
+        self.assertEqual(
+            run.call_args.args[0],
+            ["/usr/bin/pio", "pkg", "outdated", "-e", "ESP8266_DEBUG"],
+        )
+
+    @mock.patch.object(audit_dependencies.subprocess, "run")
+    def test_failed_environment_is_reported(self, run: mock.Mock) -> None:
+        run.return_value = mock.Mock(returncode=1, stdout="platform setup failed\n")
+        passed, output = audit_dependencies.audit_environment(
+            "/usr/bin/pio", "ESP32C6_IRRIGATION"
+        )
+        self.assertFalse(passed)
+        self.assertEqual(output, "platform setup failed")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Add a non-updating PlatformIO dependency audit that checks every configured environment independently and reports upgrade candidates without modifying project dependency declarations.

## Changes

- Add `tools/audit_dependencies.py` with all-environment default behavior and repeatable `--env` filtering.
- Continue auditing remaining targets when one environment fails.
- Explain the meaning and limitations of `Current`, `Wanted`, `Latest`, and moving Git dependencies.
- Add six host regression tests for parsing, filtering, failure isolation, and exit behavior.
- Document usage in the README and release workflow.
- Mark the dependency-audit TODO complete and add the change to the 9.182-dev changelog.

## Why

A single dependency check can stop at a broken target and hide results for every other environment. That happened with the two C6 environments during validation. Also, an available update is not automatically a safe update: for example, PlatformIO reports Espressif32 7.0.1 while this project currently uses 6.4.0. The audit therefore reports findings but never updates dependency declarations.

## Validation

- `python3 -B tools/check_project.py --quick`
  - 25 host tests passed.
  - Python syntax, JavaScript syntax, generated web assets, conflict-marker, and whitespace checks passed.
  - Release metadata: 0 failures; the two expected warnings are the test environments intentionally disabling `WEB_SECURE_ON`.
- `python3 tools/audit_dependencies.py --env ESP8266_DEBUG`
  - Passed and reported available package/Git revisions.
- Full real audit across all 11 configured environments:
  - 9 environments passed.
  - The two C6 environments failed independently because the existing pioarduino environment could not install its Python dependencies; results for all remaining environments were still retained.
- `git diff --check`
  - Passed.

## Notes

- No package versions or `platformio.ini` dependency declarations are changed.
- No firmware behavior is changed.
- PlatformIO may refresh its own registry/cache or prepare an environment while inspecting dependencies.
- `Latest` is information, not an upgrade recommendation; every dependency change still requires target builds and appropriate hardware checks.
- This PR does not claim to fix the existing C6 Python-environment failure.
