### PR TITLE
fix(esp8266): reclaim network heap before OTA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+- **ESP8266 HTTPS firmware updates no longer run out of memory after v9.198.**
+  Before BearSSL starts, the firmware now drains the live WebUI event stream,
+  disconnects both MQTT transports, and temporarily releases the 3.5 KB device
+  history buffer. A strict heap gate still refuses unsafe attempts cleanly.
+- The device history remains available during normal operation and is recreated
+  automatically if an update fails and the running firmware resumes.
+
+### Validation
+- Two consecutive real-board updates from a 9.197-labelled ESP8266 test build to
+  the official 9.198 release completed successfully and rebooted into 9.198. The
+  measured pre-TLS reserves were 16,792/12,712 bytes and 16,632/12,296 bytes
+  (free heap/largest contiguous block).
+
 ## [9.198] - 2026-08-24
 
 ### Added

--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -1,8 +1,8 @@
 # EasyIot - To Do
 
 - Created by: Alexandru Hauzman
-- Updated: 23.08.2026
-- Current upstream version: 9.192
+- Updated: 25.08.2026
+- Current upstream version: 9.198
 
 ## Important Notes
 
@@ -33,6 +33,7 @@
 
 1. [ ] Improve the Functions tab layout: make the add-function form clearer and more compact, visually delimit each configured feature as its own card, and use a responsive two-column grid on wider screens that stacks to one column on phones. Files: `webpanel/index.html`, `webpanel/css/styles.css`, `webpanel/js/index.js`
 2. [ ] Add a subtle left-edge health indicator to relevant status badges and diagnostic cards: green for healthy/connected, orange for degraded/retrying, red only for actual errors/disconnection, and gray for disabled/unknown. Keep the existing text or icon so status never relies on color alone; normal actuator OFF states and intentionally disabled MQTT must not appear as errors. Files: `webpanel/index.html`, `webpanel/css/styles.css`, `webpanel/js/index.js`
+3. [ ] Make the automatic-OTA page recover truthfully without a manual refresh: show the returned error after a failed attempt, and fully reload the WebUI/login state after the rebooted device confirms the new version. The current redirect page can remain on “updating” even though the firmware has already failed safely and restarted its WebServer. Files: `webpanel/js/index.js`, `src/WebServer.cpp`
 
 ## Testing & CI (P2 - Deferred / Later)
 
@@ -41,6 +42,7 @@
 3. [ ] Complete hardware testing of the 9.187 safety batch on ESP8266 and ESP32: accepted and rejected live pin changes, garden-valve OFF behavior after save/power-cycle, physical/MQTT/Cloud traffic during configuration, and failed/successful manual and automatic OTA recovery.
 4. [ ] Capture and diagnose the non-reproduced ESP32-C6 task-watchdog reset seen during WebUI/control stress; retain the complete task report and backtrace before changing watchdog or scheduling behavior.
 5. [ ] Hardware-test full non-secret recovery on ESP32, ESP32-C3 and ESP32-C6, including replacement-device recovery, wrong-variant rejection and interrupted two-file transaction rollback.
+6. [ ] Add an automated ESP8266 static-RAM regression budget and make the real-board HTTPS OTA gate mandatory for changes that grow RAM or alter WebUI/MQTT/network lifecycles. Build success alone does not exercise BearSSL heap after all services connect. Files: `tools/check_project.py`, `docs/RELEASE_WORKFLOW.md`
 
 #
 
@@ -71,6 +73,7 @@
 6. [x] Validated OTA update flow over HTTPS on ESP32 (`Update Success` + reboot + reconnect to CloudIO/MQTT; `HTTPS result: 200`, `fallback=0`). File: `src/WebServer.cpp`
 7. [x] Moved captive-portal credential saving to a non-cacheable POST submission and enabled POST-body parsing in the custom async handler. Files: `include/CaptivePortal.h`, `src/WebServer.cpp`, `tools/test_captive_portal.py`
 8. [x] Re-tested configured-device captive Wi-Fi repair on ESP8266 with 9.186-dev: Save persisted the new network/name, preserved the two existing functions and pin map, restarted into STA mode, and restored WebUI and Cloud access. Files: `include/CaptivePortal.h`, `src/WebServer.cpp`, `tools/test_captive_portal.py`
+9. [x] Fixed the ESP8266 v9.198 HTTPS OTA memory regression by draining live WebUI EventSource clients, disconnecting local/Cloud MQTT, using bounded BearSSL buffers, and temporarily releasing the 3.5 KB device-history buffer. Two consecutive 9.197-labelled -> official 9.198 hardware updates passed at -69 dBm and rebooted into 9.198. Files: `include/Constants.h`, `include/DeviceLog.h`, `src/CloudIO.cpp`, `src/DeviceLog.cpp`, `src/Mqtt.cpp`, `src/WebServer.cpp`, `src/main.cpp`, `tools/test_config_updates.py`
 
 ## Firmware Safety
 

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -40,9 +40,17 @@ This document defines the standard flow for development, upstream cherry-pick PR
    - CloudIO HTTP result
    - MQTT connect
    - basic actuator/sensor control
-6. Update `CHANGELOG.md` for the release/dev line.
-7. Push `development` and prepare required CP PR(s).
-8. Keep open CP PRs minimal and grouped by scope.
+6. For any ESP8266 change that grows RAM or alters WebUI, MQTT, networking, TLS,
+   or OTA lifecycles, validate automatic HTTPS OTA on real hardware:
+   - flash the candidate with a version older than the current published release;
+   - load the WebUI and wait for CloudIO/MQTT so normal runtime allocations exist;
+   - start automatic OTA while recording free heap, largest block, and serial errors;
+   - confirm the board reboots and the WebUI reports the published version;
+   - repeat the full cycle when closing a timing-dependent or memory regression.
+   A successful build does not exercise BearSSL after all services are connected.
+7. Update `CHANGELOG.md` for the release/dev line.
+8. Push `development` and prepare required CP PR(s).
+9. Keep open CP PRs minimal and grouped by scope.
 
 ## Project Checks
 
@@ -178,9 +186,11 @@ not factory-reset the device as part of a routine rollback.
    application-only `ONOFRE_<MCU>_RELEASE_<VERSION>.bin` as a blank-chip image
    for ESP32-family devices; it does not include the bootloader and partition
    data.
-3. Expect full-flash recovery to be capable of erasing configuration. Re-enter
-   the configuration manually using a separately protected record. The current
-   WebUI export is a non-secret diagnostic snapshot, not a restorable backup.
+3. Expect full-flash recovery to be capable of erasing configuration. Provision
+   the replacement firmware with the required local passwords, then restore a
+   separately protected `easyiot-backup` from **System -> Access and Copy**. The
+   backup restores the complete persisted configuration for the exact hardware
+   variant but intentionally contains no Wi-Fi, panel, MQTT, or Cloud passwords.
 4. If rebuilding from source is unavoidable, check out the exact known-good
    commit/tag, select the exact PlatformIO environment, build it, and record the
    binary and checksum used.

--- a/include/CloudIO.h
+++ b/include/CloudIO.h
@@ -4,6 +4,10 @@
 void connectToCloudIO();
 void startCloudIOWatchdog();
 bool cloudIOConnected();
+/** Force the asynchronous cloud transport idle before ESP8266 OTA asks BearSSL
+    for its largest allocations. The normal service loop reconnects it if the
+    update fails and the running firmware returns. */
+void disconnectCloudIOForUpdate();
 void notifyStateToCloudIO(const char *topic, const char *state);
 /** Publishes the whole irrigation picture — schedule, running cycle, and the
     countdown of every open valve — as one retained message. Cheap enough to call

--- a/include/Constants.h
+++ b/include/Constants.h
@@ -173,11 +173,10 @@ namespace constanstsCloudIO
     // cloudio.bhonofre.pt negotiates RFC 6066 maximum fragment length. The
     // BearSSL default 16 KB receive buffer cannot coexist with the running
     // WebUI/MQTT heap on an ESP8266. Cloud sync can run during a memory-heavy
-    // startup, so it uses the smallest negotiated fragment. OTA runs only
-    // after the WebUI is stopped and has enough measured headroom for 2 KB,
-    // which avoids making the firmware download unnecessarily slow.
+    // startup, so it uses the smallest negotiated fragment. OTA also uses that
+    // fragment size now that v9.198's runtime state leaves less handshake heap.
     constexpr int cloudTlsReceiveBufferSize{512};
-    constexpr int otaTlsReceiveBufferSize{2048};
+    constexpr int otaTlsReceiveBufferSize{512};
     constexpr int tlsTransmitBufferSize{512};
     // Cloud sync runs with the WebUI and other services alive. HTTPClient also
     // allocates request/header storage after the TLS connection is established,
@@ -185,8 +184,12 @@ namespace constanstsCloudIO
     // reserve is unavailable, CloudIO uses its existing plain-HTTP fallback.
     constexpr uint32_t cloudTlsMinimumFreeHeap{22000};
     constexpr uint32_t cloudTlsMinimumMaxBlock{12000};
-    constexpr uint32_t otaTlsMinimumFreeHeap{10000};
-    constexpr uint32_t otaTlsMinimumMaxBlock{4096};
+    // v9.198 reproduced a BearSSL allocation failure at 12,960 bytes free with
+    // a 9,912-byte largest block. Never enter TLS near that measured cliff:
+    // close browser/MQTT transports first, then require useful reserve for both
+    // the handshake and the updater's request/header allocations.
+    constexpr uint32_t otaTlsMinimumFreeHeap{15000};
+    constexpr uint32_t otaTlsMinimumMaxBlock{11000};
 #endif
     constexpr const char *configUrl{"https://cloudio.bhonofre.pt/devices/config"};
 #ifdef HAN_MODE

--- a/include/DeviceLog.h
+++ b/include/DeviceLog.h
@@ -17,8 +17,9 @@
  * an update, a watering cycle, a configuration refused. A per-event log would fill
  * the buffer before anyone read it.
  *
- * RAM is the constraint that shapes it: entries are a fixed size and the buffer is
- * static, so it cannot fragment the heap on an ESP8266 that has ~30 KB to live on.
+ * RAM is the constraint that shapes it: entries are fixed-size. ESP32 keeps the
+ * storage static; ESP8266 allocates it once at boot so OTA can explicitly reclaim
+ * those bytes before BearSSL, then recreate an empty history after a failed update.
  */
 
 #ifdef ESP8266
@@ -36,5 +37,10 @@ String deviceLogText();
 
 /** Uptime-stamped so the reader can tell a boot-time line from a later one. */
 void deviceLogClear();
+
+/** Releases the ESP8266 history storage before a memory-heavy OTA handshake.
+ *  The next deviceLog/deviceLogText call recreates an empty buffer if the
+ *  running firmware returns after a failed or unnecessary update. */
+void deviceLogReleaseForUpdate();
 
 #endif

--- a/include/Mqtt.h
+++ b/include/Mqtt.h
@@ -4,6 +4,8 @@
 void publishOnMqtt(const char *topic, const char *payload, bool retain);
 void subscribeOnMqtt(const char *topic);
 void setupMQTT(bool forceDisconnect);
+/** Close the local broker socket before a memory-heavy ESP8266 OTA. */
+void disconnectMqttForUpdate();
 void loopMqtt();
 void unsubscribeOnMqtt(const char *topic);
 bool mqttConnected();

--- a/src/CloudIO.cpp
+++ b/src/CloudIO.cpp
@@ -412,6 +412,24 @@ bool cloudIOConnected()
   return loadCloudMqttConnectedState();
 }
 
+void disconnectCloudIOForUpdate()
+{
+  // performUpdate() blocks the main service loop. Make the transport unavailable
+  // before closing it so no feature publisher can enqueue another packet while
+  // ESP8266 is trying to assemble one large free block for BearSSL.
+  cloudMqttSubscriptionsPending = false;
+  cloudMqttReconnectPending = false;
+  storeCloudMqttConnectedState(false);
+  mqttClient.disconnect(true);
+  // A clean session should leave no QoS state behind. Explicitly release any
+  // queued packet now rather than carry its heap across the OTA handshake.
+  mqttClient.clearQueue();
+  enterCloudMqttTransportState(CloudMqttTransportState::DISCONNECTED);
+  // On failure, serviceCloudIOMqtt() resumes on the next main-loop pass and
+  // reconnects from the immutable active runtime. Success reboots instead.
+  cloudMqttReconnectPending = activeCloudMqttRuntimeValid;
+}
+
 void onMqttMessage(char *topic, char *payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total)
 {
   (void)properties;

--- a/src/DeviceLog.cpp
+++ b/src/DeviceLog.cpp
@@ -1,11 +1,40 @@
 #include "DeviceLog.h"
 #include <stdarg.h>
+#include <stdlib.h>
 
 namespace
 {
+#ifdef ESP8266
+  char *buffer{nullptr};
+#else
   char buffer[kDeviceLogLines][kDeviceLogLineSize];
+#endif
   size_t nextLine{0};
   bool wrapped{false};
+
+  bool ensureBuffer()
+  {
+#ifdef ESP8266
+    if (buffer == nullptr)
+    {
+      buffer = static_cast<char *>(calloc(kDeviceLogLines, kDeviceLogLineSize));
+      if (buffer == nullptr)
+        return false;
+      nextLine = 0;
+      wrapped = false;
+    }
+#endif
+    return true;
+  }
+
+  char *lineAt(size_t index)
+  {
+#ifdef ESP8266
+    return buffer + index * kDeviceLogLineSize;
+#else
+    return buffer[index];
+#endif
+  }
 
   /** Milliseconds since boot as h:mm:ss, which is what makes a line placeable:
       "at 0:00:00" is the boot itself, "at 2:14:07" is something that happened
@@ -23,7 +52,9 @@ void deviceLog(const char *format, ...)
   char stamp[12];
   stampInto(stamp, sizeof(stamp));
 
-  char *line = buffer[nextLine];
+  char fallback[kDeviceLogLineSize] = {};
+  const bool storeLine = ensureBuffer();
+  char *line = storeLine ? lineAt(nextLine) : fallback;
   const int written = snprintf(line, kDeviceLogLineSize, "%s ", stamp);
   if (written > 0 && (size_t)written < kDeviceLogLineSize)
   {
@@ -33,9 +64,12 @@ void deviceLog(const char *format, ...)
     va_end(args);
   }
 
-  nextLine = (nextLine + 1) % kDeviceLogLines;
-  if (nextLine == 0)
-    wrapped = true;
+  if (storeLine)
+  {
+    nextLine = (nextLine + 1) % kDeviceLogLines;
+    if (nextLine == 0)
+      wrapped = true;
+  }
 
 #ifdef DEBUG_ONOFRE
   // Also on the wire when someone is actually looking at it.
@@ -46,6 +80,8 @@ void deviceLog(const char *format, ...)
 String deviceLogText()
 {
   String out;
+  if (!ensureBuffer())
+    return out;
   // Reserve once: growing a String line by line on an ESP8266 is how the heap
   // gets fragmented by the very code meant to help diagnose it.
   const size_t count = wrapped ? kDeviceLogLines : nextLine;
@@ -53,7 +89,7 @@ String deviceLogText()
   const size_t start = wrapped ? nextLine : 0;
   for (size_t i = 0; i < count; i++)
   {
-    const char *line = buffer[(start + i) % kDeviceLogLines];
+    const char *line = lineAt((start + i) % kDeviceLogLines);
     if (line[0] == '\0')
       continue;
     out += line;
@@ -64,8 +100,20 @@ String deviceLogText()
 
 void deviceLogClear()
 {
+  if (!ensureBuffer())
+    return;
   nextLine = 0;
   wrapped = false;
   for (size_t i = 0; i < kDeviceLogLines; i++)
-    buffer[i][0] = '\0';
+    lineAt(i)[0] = '\0';
+}
+
+void deviceLogReleaseForUpdate()
+{
+#ifdef ESP8266
+  free(buffer);
+  buffer = nullptr;
+  nextLine = 0;
+  wrapped = false;
+#endif
 }

--- a/src/Mqtt.cpp
+++ b/src/Mqtt.cpp
@@ -111,6 +111,14 @@ void setupMQTT(bool forceDisconnect)
     mqttClient.setCallback(callbackMqtt);
 }
 
+void disconnectMqttForUpdate()
+{
+    if (mqttConnected())
+    {
+        mqttClient.disconnect();
+    }
+}
+
 void loopMqtt()
 {
     // PubSubClient is synchronous: connect(), loop(), callback dispatch, state

--- a/src/WebServer.cpp
+++ b/src/WebServer.cpp
@@ -149,6 +149,10 @@ AutoUpdateResult performUpdate()
   otaStatus.percent = 0;
   otaStatus.error[0] = '\0';
 #ifdef ESP8266
+  // Device history is useful while the firmware runs, but its 3.5 KB buffer is
+  // disposable across an update (success reboots; failure starts a fresh log).
+  // Reclaim it before HTTPClient and BearSSL begin their allocation sequence.
+  deviceLogReleaseForUpdate();
   ESPhttpUpdate.onProgress([](int done, int total)
                            { otaStatus.percent = total > 0 ? (int)((int64_t)done * 100 / total) : 0; });
 #else
@@ -165,20 +169,20 @@ AutoUpdateResult performUpdate()
   if (useHttps)
   {
 #ifdef ESP8266
+#ifdef DEBUG_ONOFRE
+    const uint32_t heapBeforeTls = ESP.getFreeHeap();
+    const uint32_t maxBlockBeforeTls = ESP.getMaxFreeBlockSize();
+    const uint8_t fragmentationBeforeTls = ESP.getHeapFragmentation();
+    Log.notice("%s OTA TLS gate: heap=%u maxBlock=%u fragmentation=%u%% rssi=%d" CR,
+               tags::system,
+               heapBeforeTls,
+               maxBlockBeforeTls,
+               fragmentationBeforeTls,
+               WiFi.RSSI());
+#endif
     if (ESP.getFreeHeap() >= constanstsCloudIO::otaTlsMinimumFreeHeap &&
         ESP.getMaxFreeBlockSize() >= constanstsCloudIO::otaTlsMinimumMaxBlock)
     {
-#ifdef DEBUG_ONOFRE
-      const uint32_t heapBeforeTls = ESP.getFreeHeap();
-      const uint32_t maxBlockBeforeTls = ESP.getMaxFreeBlockSize();
-      const uint8_t fragmentationBeforeTls = ESP.getHeapFragmentation();
-      Log.notice("%s OTA TLS before: heap=%u maxBlock=%u fragmentation=%u%% rssi=%d" CR,
-                 tags::system,
-                 heapBeforeTls,
-                 maxBlockBeforeTls,
-                 fragmentationBeforeTls,
-                 WiFi.RSSI());
-#endif
       BearSSL::WiFiClientSecure client;
       client.setInsecure();
       client.setBufferSizes(constanstsCloudIO::otaTlsReceiveBufferSize,
@@ -251,7 +255,9 @@ AutoUpdateResult performUpdate()
   case HTTP_UPDATE_OK:
     otaStatus.state = OtaState::DONE;
     otaStatus.percent = 100;
+#ifndef ESP8266
     deviceLog("atualizacao gravada");
+#endif
 #ifdef DEBUG_ONOFRE
     Log.notice("HTTP_UPDATE_OK");
 #endif
@@ -1185,7 +1191,32 @@ void stopWebserver()
 #ifdef DEBUG_ONOFRE
   Log.notice("%s WEBSERVER STOP" CR, tags::system);
 #endif
+#ifdef ESP8266
+  const size_t eventClientsBeforeClose = events.count();
+#endif
+  // server.end() stops accepting new requests but does not close an established
+  // EventSource client. That live AsyncTCP connection kept scarce ESP8266 heap
+  // pinned throughout OTA and also left the browser attached to a dead stream.
+  events.close();
   server.end();
+#ifdef ESP8266
+  // AsyncEventSource closes gracefully: ESPAsyncTCP does not release its PCB
+  // until the next TCP poll (normally within 500 ms). A fixed short delay made
+  // OTA nondeterministic, so wait for the observed client to disappear while
+  // retaining a hard bound if the network stack is unhealthy.
+  const uint32_t closeStartedAt = millis();
+  while (events.count() > 0 && millis() - closeStartedAt < 2000U)
+  {
+    delay(10);
+  }
+#ifdef DEBUG_ONOFRE
+  Log.notice("%s OTA WebUI drain: clients=%u->%u waited=%ums" CR,
+             tags::system,
+             static_cast<unsigned>(eventClientsBeforeClose),
+             static_cast<unsigned>(events.count()),
+             millis() - closeStartedAt);
+#endif
+#endif
 }
 void startWebserver()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -181,6 +181,21 @@ void checkInternalRoutines()
     else
     {
       stopWebserver();
+#ifdef ESP8266
+      disconnectMqttForUpdate();
+      disconnectCloudIOForUpdate();
+      // AsyncTCP releases its PCB/buffers from deferred callbacks. Yield briefly
+      // before measuring the OTA gate; otherwise the log can say the services
+      // stopped while their heap is still owned by the network stack.
+      delay(100);
+#ifdef DEBUG_ONOFRE
+      Log.notice("%s OTA services stopped: heap=%u maxBlock=%u fragmentation=%u%%" CR,
+                 tags::system,
+                 ESP.getFreeHeap(),
+                 ESP.getMaxFreeBlockSize(),
+                 ESP.getHeapFragmentation());
+#endif
+#endif
       const AutoUpdateResult updateResult = performUpdate();
       if (updateResult == AutoUpdateResult::UPDATED)
       {

--- a/tools/test_config_updates.py
+++ b/tools/test_config_updates.py
@@ -32,6 +32,7 @@ PERSISTENCE_SOURCE = ROOT / "src" / "Persistence.cpp"
 IRRIGATION_SOURCE = ROOT / "src" / "Irrigation.cpp"
 HOME_ASSISTANT_SOURCE = ROOT / "src" / "HomeAssistantMqttDiscovery.cpp"
 MQTT_SOURCE = ROOT / "src" / "Mqtt.cpp"
+DEVICE_LOG_SOURCE = ROOT / "src" / "DeviceLog.cpp"
 
 
 def block_after(source: str, pattern: str) -> str:
@@ -124,6 +125,7 @@ class ConfigUpdateSourceContracts(unittest.TestCase):
         cls.irrigation = IRRIGATION_SOURCE.read_text(encoding="utf-8")
         cls.homeassistant = HOME_ASSISTANT_SOURCE.read_text(encoding="utf-8")
         cls.mqtt = MQTT_SOURCE.read_text(encoding="utf-8")
+        cls.device_log = DEVICE_LOG_SOURCE.read_text(encoding="utf-8")
 
     def assertOrdered(self, source: str, *needles: str) -> None:  # noqa: N802
         cursor = -1
@@ -1475,8 +1477,10 @@ class ConfigUpdateSourceContracts(unittest.TestCase):
 
     def test_esp8266_https_uses_bounded_negotiated_tls_buffers(self) -> None:
         self.assertRegex(self.constants, r"cloudTlsReceiveBufferSize\s*\{\s*512\s*\}")
-        self.assertRegex(self.constants, r"otaTlsReceiveBufferSize\s*\{\s*2048\s*\}")
+        self.assertRegex(self.constants, r"otaTlsReceiveBufferSize\s*\{\s*512\s*\}")
         self.assertRegex(self.constants, r"tlsTransmitBufferSize\s*\{\s*512\s*\}")
+        self.assertRegex(self.constants, r"otaTlsMinimumFreeHeap\s*\{\s*15000\s*\}")
+        self.assertRegex(self.constants, r"otaTlsMinimumMaxBlock\s*\{\s*11000\s*\}")
         self.assertIn("client.setBufferSizes(constanstsCloudIO::cloudTlsReceiveBufferSize", self.cloud)
         self.assertIn("client.setBufferSizes(constanstsCloudIO::otaTlsReceiveBufferSize", self.server)
         self.assertIn("ESP.getFreeHeap() >= constanstsCloudIO::cloudTlsMinimumFreeHeap", self.cloud)
@@ -1491,6 +1495,47 @@ class ConfigUpdateSourceContracts(unittest.TestCase):
             "BearSSL::WiFiClientSecure client;",
         )
         self.assertIn("client.getLastSSLError(otaTlsError", self.server)
+
+    def test_esp8266_ota_releases_live_network_transports_before_tls(self) -> None:
+        routines = block_after(self.main, r"void\s+checkInternalRoutines\s*\(\s*\)")
+        ota = block_after(
+            routines,
+            r"if\s*\(\s*config\.takeAutoUpdateRequest\s*\(\s*\)\s*\)",
+        )
+        self.assertOrdered(
+            ota,
+            "stopWebserver();",
+            "disconnectMqttForUpdate();",
+            "disconnectCloudIOForUpdate();",
+            "delay(100);",
+            "performUpdate();",
+        )
+
+        stop = block_after(self.server, r"void\s+stopWebserver\s*\(\s*\)")
+        self.assertOrdered(stop, "events.close();", "server.end();")
+        self.assertIn("while (events.count() > 0", stop)
+        self.assertIn("millis() - closeStartedAt < 2000U", stop)
+
+        update = block_after(self.server, r"AutoUpdateResult\s+performUpdate\s*\(\s*\)")
+        self.assertOrdered(
+            update,
+            'deviceLog("atualizacao pedida");',
+            "deviceLogReleaseForUpdate();",
+            "ESPhttpUpdate.update(client, otaUrl, String(VERSION));",
+        )
+        self.assertIn("calloc(kDeviceLogLines, kDeviceLogLineSize)", self.device_log)
+        self.assertIn("free(buffer);", self.device_log)
+
+        cloud_disconnect = block_after(
+            self.cloud, r"void\s+disconnectCloudIOForUpdate\s*\(\s*\)"
+        )
+        self.assertOrdered(
+            cloud_disconnect,
+            "storeCloudMqttConnectedState(false);",
+            "mqttClient.disconnect(true);",
+            "mqttClient.clearQueue();",
+            "cloudMqttReconnectPending = activeCloudMqttRuntimeValid;",
+        )
     def test_firmware_header_badge_links_to_update_panel(self) -> None:
         self.assertIn('id="h-fw-link"', self.panel_html)
         self.assertIn('title="Firmware instalado" disabled', self.panel_html)


### PR DESCRIPTION
## Summary

Fix ESP8266 automatic HTTPS OTA after v9.198 exhausted BearSSL heap and either failed or rebooted with an OOM exception.

## What changed

- Drain live WebUI EventSource clients before stopping the server, waiting up to 2 seconds for ESPAsyncTCP to release their PCBs.
- Disconnect local MQTT and CloudIO MQTT before the blocking OTA handshake; CloudIO reconnects normally if OTA returns.
- On ESP8266, allocate the 3.5 KB device-history buffer once during normal operation and release it before OTA. A failed/no-update attempt recreates an empty history automatically.
- Use 512-byte negotiated BearSSL receive/transmit buffers and keep a strict 15 KB free-heap / 11 KB largest-block gate.
- Add source-contract coverage for teardown ordering, bounded waiting, memory gates, and history-buffer reclamation.
- Record the stale OTA progress-page behavior as a separate WebUI follow-up instead of hiding it inside this firmware fix.
- Make real-board ESP8266 HTTPS OTA a release gate for RAM/network-lifecycle changes, and correct the recovery guide to describe the restorable non-secret backup.

## Evidence

The v9.198 regression reproduced at good Wi-Fi signal. One failing attempt entered TLS with 13,272 bytes free and a 12,864-byte largest block, then threw `OOM` while allocating the 1,496-byte X.509 validator.

After this fix, two consecutive real-board OTA cycles succeeded from a 9.197-labelled build to the official 9.198 ESP8266 release:

1. WebUI clients `1 -> 0`; TLS gate 16,792 bytes free / 12,712-byte largest block; RSSI -69 dBm; reboot confirmed FW 9.198.
2. WebUI clients `2 -> 0`; TLS gate 16,632 bytes free / 12,296-byte largest block; RSSI -69 dBm; reboot confirmed FW 9.198.

ESP8266 static RAM dropped from 55,692 to 52,140 bytes while preserving device history during normal operation.

## Validation

- `python3 tools/check_project.py --quick`: 114 host tests; all 6 checks passed. Only the two intentional insecure-test-environment warnings remain.
- `ESP8266_DEBUG`: success, RAM 63.6%, flash 73.6%.
- `ESP32_DEBUG`: success, RAM 23.1%, flash 42.5%.
- `git diff --check`: passed.

## Scope

The runtime teardown and BearSSL memory handling are ESP8266-only. ESP32 compiles successfully but this PR does not claim ESP32 OTA hardware validation. The separate stale progress-page/full-page-refresh improvement is tracked in `TODO_IMPROVEMENTS.md` but is not implemented here.
