### PR TITLE
build(esp8266): enforce static RAM budgets

### DIFF
--- a/.github/workflows/firmware-ota.yml
+++ b/.github/workflows/firmware-ota.yml
@@ -143,6 +143,10 @@ jobs:
       - name: Build ${{ matrix.env }}
         run: pio run -e ${{ matrix.env }}
 
+      - name: Verify ESP8266 static-RAM budget
+        if: ${{ startsWith(matrix.env, 'ESP8266') }}
+        run: python3 tools/check_ram_budget.py --env ${{ matrix.env }}
+
       - name: Rename binary
         id: bin
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project are documented in this file.
 
+## Development after 9.200 - 2026-08-28
+
+### Added
+- **ESP8266 builds now have an evidence-based static-RAM release gate.** Normal
+  and HAN release/debug profiles measure `.data + .rodata + .bss` directly from
+  the linked ELF, report their byte margin and change from the reviewed v9.200
+  baseline, and refuse to publish a candidate above the configured ceiling.
+- The release workflow repeats the guard explicitly in CI. Budget validation is
+  also part of the quick project checks, with host tests covering configuration,
+  ELF parsing, pass/fail boundaries, publication ordering, and CI wiring.
+
+### Validation
+- v9.200 baselines: 47,780 bytes (`ESP8266_RELEASE`), 47,796 bytes
+  (`ESP8266-HAN_RELEASE`), 52,188 bytes (`ESP8266_DEBUG`), and 52,204 bytes
+  (`ESP8266-HAN_DEBUG`). Release ceilings are 50,000 bytes and debug ceilings
+  are 54,000 bytes; both would reject the known v9.198 OTA regression builds.
+- Static RAM remains an early warning only. Changes affecting RAM or network
+  lifecycles still require automatic HTTPS OTA on real ESP8266 hardware because
+  an ELF cannot measure runtime heap fragmentation.
+
 ## [9.200] - 2026-08-25
 
 ### Fixed

--- a/TODO_IMPROVEMENTS.md
+++ b/TODO_IMPROVEMENTS.md
@@ -1,8 +1,8 @@
 # EasyIot - To Do
 
 - Created by: Alexandru Hauzman
-- Updated: 25.08.2026
-- Current upstream version: 9.198
+- Updated: 28.08.2026
+- Current upstream version: 9.200
 
 ## Important Notes
 
@@ -42,7 +42,6 @@
 3. [ ] Complete hardware testing of the 9.187 safety batch on ESP8266 and ESP32: accepted and rejected live pin changes, garden-valve OFF behavior after save/power-cycle, physical/MQTT/Cloud traffic during configuration, and failed/successful manual and automatic OTA recovery.
 4. [ ] Capture and diagnose the non-reproduced ESP32-C6 task-watchdog reset seen during WebUI/control stress; retain the complete task report and backtrace before changing watchdog or scheduling behavior.
 5. [ ] Hardware-test full non-secret recovery on ESP32, ESP32-C3 and ESP32-C6, including replacement-device recovery, wrong-variant rejection and interrupted two-file transaction rollback.
-6. [ ] Add an automated ESP8266 static-RAM regression budget and make the real-board HTTPS OTA gate mandatory for changes that grow RAM or alter WebUI/MQTT/network lifecycles. Build success alone does not exercise BearSSL heap after all services connect. Files: `tools/check_project.py`, `docs/RELEASE_WORKFLOW.md`
 
 #
 
@@ -108,8 +107,9 @@
 1. [x] Added PR workflow guide (development -> cherry-pick branch -> upstream PR). File: `docs/RELEASE_WORKFLOW.md`
 2. [x] Added branch naming convention for external CP branches. File: `docs/RELEASE_WORKFLOW.md`
 3. [x] Added release checklist document in repo docs. File: `docs/RELEASE_WORKFLOW.md`
-4. [x] Added script to generate release notes draft from commits. File: `tools/generate_release_notes.sh`
-5. [x] Added an exact-variant rollback playbook for WebUI OTA recovery, full-flash recovery, configuration restore, containment, and post-rollback verification. File: `docs/RELEASE_WORKFLOW.md`
+4. [x] Added an evidence-based ESP8266 static-RAM guard for normal/HAN release and debug profiles. It measures `.data + .rodata + .bss` from the linked ELF before publishing a local candidate, repeats explicitly in release CI, reports byte margin/baseline delta, and fails above the reviewed limit. Real-board HTTPS OTA remains mandatory because static RAM cannot prove runtime heap/fragmentation safety. Files: `tools/check_ram_budget.py`, `tools/esp8266_ram_budgets.json`, `tools/post_extra_script.py`, `tools/check_project.py`, `.github/workflows/firmware-ota.yml`, `docs/RELEASE_WORKFLOW.md`
+5. [x] Added script to generate release notes draft from commits. File: `tools/generate_release_notes.sh`
+6. [x] Added an exact-variant rollback playbook for WebUI OTA recovery, full-flash recovery, configuration restore, containment, and post-rollback verification. File: `docs/RELEASE_WORKFLOW.md`
 
 ## Security & API
 

--- a/docs/RELEASE_WORKFLOW.md
+++ b/docs/RELEASE_WORKFLOW.md
@@ -72,9 +72,30 @@ three environments published by CI: `ESP8266_RELEASE`,
 `ESP8266-HAN_RELEASE`, and `ESP32_RELEASE`.
 
 The quick checks validate Python and JavaScript syntax, host tests, release
-metadata, generated web-header parity, conflict markers, and whitespace. Web
-asset parity is checked in a temporary directory, so the command does not
+metadata, ESP8266 RAM-budget configuration, generated web-header parity,
+conflict markers, and whitespace. Web asset parity is checked in a temporary
+directory, so the command does not
 rewrite working-tree headers.
+
+## ESP8266 Static-RAM Gate
+
+Every `ESP8266_RELEASE`, `ESP8266-HAN_RELEASE`, `ESP8266_DEBUG`, and
+`ESP8266-HAN_DEBUG` build checks `.data + .rodata + .bss` from its linked ELF
+before publishing the local candidate. Release CI repeats the check explicitly.
+The reviewed v9.200 baselines and ceilings live in
+`tools/esp8266_ram_budgets.json`; run a check against an existing build with:
+
+- `python3 tools/check_ram_budget.py --env ESP8266_RELEASE`
+
+An over-budget build is a required investigation, not permission to raise the
+number until CI turns green. Review which ELF sections/symbols grew and why. If
+an intentional change needs a new ceiling, record the measured baseline and
+repeat real-board automatic HTTPS OTA with normal WebUI, CloudIO, and MQTT
+allocations active before approving it.
+
+This gate catches static allocation growth only. It cannot measure runtime heap,
+largest contiguous block, fragmentation, or timing, so it does not replace the
+real-board OTA checklist above.
 
 ## Dependency Audit
 

--- a/tools/check_project.py
+++ b/tools/check_project.py
@@ -175,6 +175,12 @@ def check_release_metadata() -> None:
         raise CheckWarning(f"metadata validator reported {warning_count} warning(s)")
 
 
+def check_ram_budget_config() -> None:
+    run_command(
+        [sys.executable, str(TOOLS / "check_ram_budget.py"), "--validate-config"]
+    )
+
+
 def check_javascript() -> None:
     node = require_command("node")
     run_command([node, "--check", str(ROOT / "webpanel" / "js" / "index.js")])
@@ -281,6 +287,7 @@ def main() -> int:
         ("Python syntax", check_python_syntax),
         ("Host unit tests", check_unit_tests),
         ("Release metadata", check_release_metadata),
+        ("ESP8266 RAM budget configuration", check_ram_budget_config),
         ("JavaScript syntax", check_javascript),
         ("Generated web assets", check_generated_web_assets),
         ("Conflict markers", check_conflict_markers),

--- a/tools/check_ram_budget.py
+++ b/tools/check_ram_budget.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Enforce evidence-based ESP8266 static-RAM budgets from a linked ELF."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_BUDGET_FILE = Path(__file__).with_name("esp8266_ram_budgets.json")
+DEFAULT_BUILD_ROOT = ROOT / ".pio" / "build"
+EXPECTED_ENVIRONMENTS = {
+    "ESP8266_RELEASE",
+    "ESP8266-HAN_RELEASE",
+    "ESP8266_DEBUG",
+    "ESP8266-HAN_DEBUG",
+}
+
+
+class BudgetError(RuntimeError):
+    """A configuration, tool, or ELF measurement error."""
+
+
+def positive_integer(value: Any, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise BudgetError(f"{field} must be a positive integer")
+    return value
+
+
+def load_budgets(
+    path: Path = DEFAULT_BUDGET_FILE,
+) -> tuple[str, tuple[str, ...], dict[str, dict[str, int]]]:
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise BudgetError(f"cannot read budget file {path}: {error}") from error
+    except json.JSONDecodeError as error:
+        raise BudgetError(f"invalid JSON in {path}: {error}") from error
+
+    if not isinstance(document, dict) or document.get("schema_version") != 1:
+        raise BudgetError("budget file must use schema_version 1")
+
+    baseline_version = document.get("baseline_version")
+    if not isinstance(baseline_version, str) or not re.fullmatch(
+        r"[0-9]+(?:\.[0-9]+){1,2}", baseline_version
+    ):
+        raise BudgetError("baseline_version must be a release version such as 9.200")
+
+    raw_sections = document.get("ram_sections")
+    if (
+        not isinstance(raw_sections, list)
+        or not raw_sections
+        or any(not isinstance(section, str) or not section.startswith(".") for section in raw_sections)
+        or len(raw_sections) != len(set(raw_sections))
+    ):
+        raise BudgetError("ram_sections must be a non-empty list of unique ELF section names")
+
+    raw_environments = document.get("environments")
+    if not isinstance(raw_environments, dict):
+        raise BudgetError("environments must be an object")
+    missing = EXPECTED_ENVIRONMENTS - set(raw_environments)
+    extra = set(raw_environments) - EXPECTED_ENVIRONMENTS
+    if missing or extra:
+        details = []
+        if missing:
+            details.append("missing " + ", ".join(sorted(missing)))
+        if extra:
+            details.append("unexpected " + ", ".join(sorted(extra)))
+        raise BudgetError("budget environments do not match the protected set: " + "; ".join(details))
+
+    environments: dict[str, dict[str, int]] = {}
+    for name, raw_budget in raw_environments.items():
+        if not isinstance(raw_budget, dict):
+            raise BudgetError(f"{name} budget must be an object")
+        baseline = positive_integer(raw_budget.get("baseline_bytes"), f"{name}.baseline_bytes")
+        limit = positive_integer(raw_budget.get("limit_bytes"), f"{name}.limit_bytes")
+        if baseline > limit:
+            raise BudgetError(f"{name}.baseline_bytes cannot exceed limit_bytes")
+        environments[name] = {"baseline_bytes": baseline, "limit_bytes": limit}
+
+    return baseline_version, tuple(raw_sections), environments
+
+
+def parse_section_sizes(output: str, required_sections: tuple[str, ...]) -> dict[str, int]:
+    found: dict[str, int] = {}
+    for line in output.splitlines():
+        match = re.fullmatch(r"\s*(\.\S+)\s+(\d+)\s+(?:0x[0-9A-Fa-f]+|\d+)\s*", line)
+        if not match or match.group(1) not in required_sections:
+            continue
+        section = match.group(1)
+        if section in found:
+            raise BudgetError(f"ELF size output contains duplicate {section} sections")
+        found[section] = int(match.group(2))
+    missing = set(required_sections) - set(found)
+    if missing:
+        raise BudgetError("ELF size output is missing required sections: " + ", ".join(sorted(missing)))
+    return found
+
+
+def locate_size_tool(explicit: str | None = None) -> Path:
+    if explicit:
+        path = Path(explicit).expanduser()
+        if path.is_file():
+            return path
+        resolved = shutil.which(explicit)
+        if resolved:
+            return Path(resolved)
+        raise BudgetError(f"ESP8266 size tool does not exist: {explicit}")
+
+    resolved = shutil.which("xtensa-lx106-elf-size")
+    if resolved:
+        return Path(resolved)
+
+    core_dir = Path(os.environ.get("PLATFORMIO_CORE_DIR", Path.home() / ".platformio"))
+    executable = "xtensa-lx106-elf-size.exe" if os.name == "nt" else "xtensa-lx106-elf-size"
+    candidate = core_dir / "packages" / "toolchain-xtensa" / "bin" / executable
+    if candidate.is_file():
+        return candidate
+    raise BudgetError("cannot find xtensa-lx106-elf-size; build/install the ESP8266 toolchain first")
+
+
+def locate_elf(environment: str, explicit: Path | None = None) -> Path:
+    if explicit is not None:
+        if not explicit.is_file():
+            raise BudgetError(f"ELF does not exist: {explicit}")
+        return explicit
+    build_dir = DEFAULT_BUILD_ROOT / environment
+    candidates = sorted(build_dir.glob("Firmware_*.elf"))
+    if len(candidates) != 1:
+        raise BudgetError(
+            f"expected exactly one Firmware_*.elf in {build_dir}, found {len(candidates)}; "
+            "build the environment first or pass --elf"
+        )
+    return candidates[0]
+
+
+def measure_sections(elf: Path, size_tool: Path, sections: tuple[str, ...]) -> dict[str, int]:
+    try:
+        result = subprocess.run(
+            [str(size_tool), "-A", str(elf)],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+    except OSError as error:
+        raise BudgetError(f"could not run {size_tool}: {error}") from error
+    if result.returncode != 0:
+        raise BudgetError(f"size tool exited with {result.returncode}: {result.stdout.strip()}")
+    return parse_section_sizes(result.stdout, sections)
+
+
+def budget_report(
+    environment: str,
+    section_sizes: dict[str, int],
+    budget: dict[str, int],
+    baseline_version: str,
+) -> tuple[bool, str]:
+    used = sum(section_sizes.values())
+    baseline = budget["baseline_bytes"]
+    limit = budget["limit_bytes"]
+    margin = limit - used
+    delta = used - baseline
+    breakdown = " + ".join(f"{name} {section_sizes[name]:,}" for name in section_sizes)
+    status = "OK" if margin >= 0 else "FAIL"
+    message = (
+        f"[{status}] {environment} static RAM: {used:,} / {limit:,} bytes "
+        f"({margin:+,} margin, {delta:+,} vs v{baseline_version} baseline); {breakdown}"
+    )
+    if margin < 0:
+        message += (
+            ". Do not raise the limit to make the build green: inspect the ELF change and repeat "
+            "real-board HTTPS OTA validation before approving a new budget."
+        )
+    return margin >= 0, message
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env", dest="environment", help="protected PlatformIO environment")
+    parser.add_argument("--elf", type=Path, help="linked ELF; defaults to .pio/build/<env>/Firmware_*.elf")
+    parser.add_argument("--size-tool", help="path/name of xtensa-lx106-elf-size")
+    parser.add_argument("--budget-file", type=Path, default=DEFAULT_BUDGET_FILE)
+    parser.add_argument("--validate-config", action="store_true", help="validate budgets without reading an ELF")
+    args = parser.parse_args(argv)
+    if not args.validate_config and not args.environment:
+        parser.error("--env is required unless --validate-config is used")
+    if args.validate_config and (args.environment or args.elf or args.size_tool):
+        parser.error("--validate-config cannot be combined with --env, --elf, or --size-tool")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        baseline_version, sections, environments = load_budgets(args.budget_file)
+        if args.validate_config:
+            print(
+                f"[OK] ESP8266 RAM budgets cover {len(environments)} environments from "
+                f"v{baseline_version}; sections: {', '.join(sections)}"
+            )
+            return 0
+        if args.environment not in environments:
+            raise BudgetError(f"no static-RAM budget for environment {args.environment}")
+        elf = locate_elf(args.environment, args.elf)
+        size_tool = locate_size_tool(args.size_tool)
+        measured = measure_sections(elf, size_tool, sections)
+        passed, message = budget_report(
+            args.environment, measured, environments[args.environment], baseline_version
+        )
+        print(message)
+        return 0 if passed else 1
+    except BudgetError as error:
+        print(f"[ERROR] {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/esp8266_ram_budgets.json
+++ b/tools/esp8266_ram_budgets.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": 1,
+  "baseline_version": "9.200",
+  "ram_sections": [".data", ".rodata", ".bss"],
+  "environments": {
+    "ESP8266_RELEASE": {
+      "baseline_bytes": 47780,
+      "limit_bytes": 50000
+    },
+    "ESP8266-HAN_RELEASE": {
+      "baseline_bytes": 47796,
+      "limit_bytes": 50000
+    },
+    "ESP8266_DEBUG": {
+      "baseline_bytes": 52188,
+      "limit_bytes": 54000
+    },
+    "ESP8266-HAN_DEBUG": {
+      "baseline_bytes": 52204,
+      "limit_bytes": 54000
+    }
+  }
+}

--- a/tools/post_extra_script.py
+++ b/tools/post_extra_script.py
@@ -9,9 +9,50 @@ from SCons.Script import Action, DefaultEnvironment  # type: ignore
 
 env = DefaultEnvironment()
 
+ESP8266_BUDGET_ENVIRONMENTS = {
+    "ESP8266_RELEASE",
+    "ESP8266-HAN_RELEASE",
+    "ESP8266_DEBUG",
+    "ESP8266-HAN_DEBUG",
+}
+
+
+def check_esp8266_ram_budget(env):
+    pioenv = env.get("PIOENV", "")
+    if pioenv not in ESP8266_BUDGET_ENVIRONMENTS:
+        return 0
+
+    project_dir = env["PROJECT_DIR"]
+    script_path = os.path.join(project_dir, "tools", "check_ram_budget.py")
+    elf_path = env.subst("$PROGPATH")
+    size_tool = env.subst("$SIZETOOL")
+    if not os.path.isfile(script_path):
+        print("ESP8266 RAM budget check failed: check_ram_budget.py not found")
+        return 1
+
+    print("")
+    print("Checking ESP8266 static-RAM budget ...")
+    result = subprocess.run(
+        [
+            sys.executable,
+            script_path,
+            "--env",
+            pioenv,
+            "--elf",
+            elf_path,
+            "--size-tool",
+            size_tool,
+        ],
+        check=False,
+    )
+    return result.returncode
+
 
 def export_firmware_candidate(target, source, env):
     pioenv = env.get("PIOENV", "")
+    if check_esp8266_ram_budget(env) != 0:
+        print("Firmware candidate not published: ESP8266 static-RAM budget failed.")
+        return 1
     project_dir = env["PROJECT_DIR"]
     script_path = os.path.join(project_dir, "tools", "export_firmware.py")
     binary_path = env.subst("$BUILD_DIR/${PROGNAME}.bin")

--- a/tools/test_ram_budget.py
+++ b/tools/test_ram_budget.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Host-only tests for the ESP8266 static-RAM budget guard."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("check_ram_budget.py")
+SPEC = importlib.util.spec_from_file_location("check_ram_budget", SCRIPT)
+assert SPEC and SPEC.loader
+check_ram_budget = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(check_ram_budget)
+
+
+class RamBudgetTests(unittest.TestCase):
+    def test_parses_platformio_esp8266_ram_sections(self) -> None:
+        output = """firmware.elf  :
+section  size  addr
+.data  1616  1073643520
+.rodata  16180  1073645200
+.bss  34392  1073661384
+Total  900000
+"""
+        self.assertEqual(
+            check_ram_budget.parse_section_sizes(output, (".data", ".rodata", ".bss")),
+            {".data": 1616, ".rodata": 16180, ".bss": 34392},
+        )
+
+    def test_rejects_missing_required_section(self) -> None:
+        with self.assertRaisesRegex(check_ram_budget.BudgetError, r"missing required sections: \.bss"):
+            check_ram_budget.parse_section_sizes(
+                ".data 100 1\n.rodata 200 2\n", (".data", ".rodata", ".bss")
+            )
+
+    def test_report_passes_at_limit_and_shows_baseline_delta(self) -> None:
+        passed, report = check_ram_budget.budget_report(
+            "ESP8266_RELEASE",
+            {".data": 1000, ".rodata": 2000, ".bss": 7000},
+            {"baseline_bytes": 9500, "limit_bytes": 10000},
+            "9.200",
+        )
+        self.assertTrue(passed)
+        self.assertIn("10,000 / 10,000 bytes", report)
+        self.assertIn("+500 vs v9.200 baseline", report)
+
+    def test_report_fails_over_limit_with_review_instruction(self) -> None:
+        passed, report = check_ram_budget.budget_report(
+            "ESP8266_RELEASE",
+            {".data": 1000, ".rodata": 2000, ".bss": 7001},
+            {"baseline_bytes": 9500, "limit_bytes": 10000},
+            "9.200",
+        )
+        self.assertFalse(passed)
+        self.assertIn("[FAIL]", report)
+        self.assertIn("-1 margin", report)
+        self.assertIn("Do not raise the limit", report)
+
+    def test_budget_file_requires_exact_protected_environment_set(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "budgets.json"
+            path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "baseline_version": "9.200",
+                        "ram_sections": [".data", ".rodata", ".bss"],
+                        "environments": {
+                            "ESP8266_RELEASE": {"baseline_bytes": 1, "limit_bytes": 2}
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(check_ram_budget.BudgetError, "missing"):
+                check_ram_budget.load_budgets(path)
+
+    def test_repository_budget_baselines_fit_limits(self) -> None:
+        baseline_version, sections, environments = check_ram_budget.load_budgets()
+        self.assertEqual(baseline_version, "9.200")
+        self.assertEqual(sections, (".data", ".rodata", ".bss"))
+        self.assertEqual(set(environments), check_ram_budget.EXPECTED_ENVIRONMENTS)
+        for budget in environments.values():
+            self.assertLessEqual(budget["baseline_bytes"], budget["limit_bytes"])
+
+    def test_candidate_publication_checks_budget_first(self) -> None:
+        source = Path(__file__).with_name("post_extra_script.py").read_text(encoding="utf-8")
+        function_start = source.index("def export_firmware_candidate")
+        check_call = source.index("check_esp8266_ram_budget(env)", function_start)
+        publish_message = source.index("Publishing local firmware candidate", function_start)
+        self.assertLess(check_call, publish_message)
+
+    def test_release_workflow_has_explicit_esp8266_budget_gate(self) -> None:
+        workflow = (Path(__file__).parents[1] / ".github" / "workflows" / "firmware-ota.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("name: Verify ESP8266 static-RAM budget", workflow)
+        self.assertIn("python3 tools/check_ram_budget.py --env ${{ matrix.env }}", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Add an evidence-based static-RAM regression gate for every publishable ESP8266 normal/HAN release and debug build. This is intended to catch the class of static-memory growth that contributed to the v9.198 BearSSL OTA regression before a candidate is published.

## Changes

- Measure `.data + .rodata + .bss` directly from each linked ESP8266 ELF.
- Protect `ESP8266_RELEASE`, `ESP8266-HAN_RELEASE`, `ESP8266_DEBUG`, and `ESP8266-HAN_DEBUG` with reviewed v9.200 baselines and separate release/debug ceilings.
- Block local firmware-candidate publication when a protected build exceeds its ceiling.
- Repeat the guard explicitly in the release CI workflow before artifact renaming/upload.
- Validate the budget configuration in quick project checks.
- Add host tests for ELF parsing, missing sections, boundary pass/fail behavior, configuration coverage, publication ordering, and CI wiring.
- Document the policy, measurements, and limitations in the changelog, TODO, and release workflow.

## Why

The v9.198 ESP8266 build compiled successfully but later lacked enough contiguous runtime heap for BearSSL during automatic HTTPS OTA. Build success and a percentage alone were not a sufficient regression gate. The reviewed ceilings would reject the known failing v9.198 memory levels while leaving measured headroom above v9.200.

## Validation

- `python3 tools/check_project.py --all`: 122 host tests; 7 source checks; `ESP8266_RELEASE`, `ESP8266-HAN_RELEASE`, and `ESP32_RELEASE` builds passed. The only warning group is the two intentional insecure TEST environments.
- `ESP8266_RELEASE`: 47,780 / 50,000 bytes, +2,220 margin.
- `ESP8266-HAN_RELEASE`: 47,796 / 50,000 bytes, +2,204 margin.
- `ESP8266_DEBUG`: 52,188 / 54,000 bytes, +1,812 margin.
- `ESP8266-HAN_DEBUG`: 52,204 / 54,000 bytes, +1,796 margin.
- All four protected builds passed with the guard executed before candidate publication.
- `ESP32_RELEASE` passed and remained outside the ESP8266 budget logic.
- A controlled one-byte-over-limit test failed the build and prevented candidate publication; the reviewed budget was restored afterward.
- `git diff --check` passed.

## Notes

- This changes build/release tooling only; it does not change firmware runtime behavior or installed devices.
- Static RAM is an early warning, not proof of OTA safety. Changes that grow RAM or alter WebUI, MQTT, or network lifecycles still require automatic HTTPS OTA on real ESP8266 hardware with normal services active.
- ESP32 and ESP32-C6 are deliberately excluded. They use different TLS stacks and memory profiles, so copying ESP8266 limits would be unsupported.